### PR TITLE
Normalize indent to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/binary.json
+++ b/binary.json
@@ -1,76 +1,76 @@
 [
     {
-      "name": "basic binary",
-      "raw": [":aGVsbG8=:"],
-      "header_type": "item",
-      "expected": [
-          {"__type": "binary", "value": "NBSWY3DP"},
-          {}]
+        "name": "basic binary",
+        "raw": [":aGVsbG8=:"],
+        "header_type": "item",
+        "expected": [
+            {"__type": "binary", "value": "NBSWY3DP"},
+            {}]
     },
     {
-      "name": "empty binary",
-      "raw": ["::"],
-      "header_type": "item",
-      "expected": [
-          {"__type": "binary", "value": ""},
-          {}]
+        "name": "empty binary",
+        "raw": ["::"],
+        "header_type": "item",
+        "expected": [
+            {"__type": "binary", "value": ""},
+            {}]
     },
     {
-      "name": "bad paddding",
-      "raw": [":aGVsbG8:"],
-      "header_type": "item",
-      "expected": [
-          {"__type": "binary", "value": "NBSWY3DP"},
-          {}],
-      "can_fail": true,
-      "canonical": [":aGVsbG8=:"]
+        "name": "bad paddding",
+        "raw": [":aGVsbG8:"],
+        "header_type": "item",
+        "expected": [
+            {"__type": "binary", "value": "NBSWY3DP"},
+            {}],
+        "can_fail": true,
+        "canonical": [":aGVsbG8=:"]
     },
     {
-      "name": "bad end delimiter",
-      "raw": [":aGVsbG8="],
-      "header_type": "item",
-      "must_fail": true
+        "name": "bad end delimiter",
+        "raw": [":aGVsbG8="],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "extra whitespace",
-      "raw": [":aGVsb G8=:"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "extra whitespace",
+        "raw": [":aGVsb G8=:"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "extra chars",
-      "raw": [":aGVsbG!8=:"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "extra chars",
+        "raw": [":aGVsbG!8=:"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "suffix chars",
-      "raw": [":aGVsbG8=!:"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "suffix chars",
+        "raw": [":aGVsbG8=!:"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "non-zero pad bits",
-      "raw": [":iZ==:"],
-      "header_type": "item",
-      "expected": [
-          {"__type": "binary", "value": "RE======"},
-          {}],
-      "can_fail": true,
-      "canonical": [":iQ==:"]
+        "name": "non-zero pad bits",
+        "raw": [":iZ==:"],
+        "header_type": "item",
+        "expected": [
+            {"__type": "binary", "value": "RE======"},
+            {}],
+        "can_fail": true,
+        "canonical": [":iQ==:"]
     },
     {
-      "name": "non-ASCII binary",
-      "raw": [":/+Ah:"],
-      "header_type": "item",
-      "expected": [
-          {"__type": "binary", "value": "77QCC==="},
-          {}]
+        "name": "non-ASCII binary",
+        "raw": [":/+Ah:"],
+        "header_type": "item",
+        "expected": [
+            {"__type": "binary", "value": "77QCC==="},
+            {}]
     },
     {
-      "name": "base64url binary",
-      "raw": [":_-Ah:"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "base64url binary",
+        "raw": [":_-Ah:"],
+        "header_type": "item",
+        "must_fail": true
     }
 ]

--- a/boolean.json
+++ b/boolean.json
@@ -1,69 +1,69 @@
 [
     {
-      "name": "basic true boolean",
-      "raw": ["?1"],
-      "header_type": "item",
-      "expected": [true, {}]
+        "name": "basic true boolean",
+        "raw": ["?1"],
+        "header_type": "item",
+        "expected": [true, {}]
     },
     {
-      "name": "basic false boolean",
-      "raw": ["?0"],
-      "header_type": "item",
-      "expected": [false, {}]
+        "name": "basic false boolean",
+        "raw": ["?0"],
+        "header_type": "item",
+        "expected": [false, {}]
     },
     {
-      "name": "unknown boolean",
-      "raw": ["?Q"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "unknown boolean",
+        "raw": ["?Q"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "whitespace boolean",
-      "raw": ["? 1"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "whitespace boolean",
+        "raw": ["? 1"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "negative zero boolean",
-      "raw": ["?-0"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "negative zero boolean",
+        "raw": ["?-0"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "T boolean",
-      "raw": ["?T"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "T boolean",
+        "raw": ["?T"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "F boolean",
-      "raw": ["?F"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "F boolean",
+        "raw": ["?F"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "t boolean",
-      "raw": ["?t"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "t boolean",
+        "raw": ["?t"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "f boolean",
-      "raw": ["?f"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "f boolean",
+        "raw": ["?f"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "spelled-out True boolean",
-      "raw": ["?True"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "spelled-out True boolean",
+        "raw": ["?True"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "spelled-out False boolean",
-      "raw": ["?False"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "spelled-out False boolean",
+        "raw": ["?False"],
+        "header_type": "item",
+        "must_fail": true
     }
 ]
-    
+

--- a/dictionary.json
+++ b/dictionary.json
@@ -1,163 +1,163 @@
 [
     {
-      "name": "basic dictionary",
-      "raw": ["en=\"Applepie\", da=:w4ZibGV0w6ZydGUK:"],
-      "header_type": "dictionary",
-      "expected": {"en": ["Applepie", {}], "da": [
-          {"__type": "binary", "value": "YODGE3DFOTB2M4TUMUFA===="},
-          {}]
-      }
+        "name": "basic dictionary",
+        "raw": ["en=\"Applepie\", da=:w4ZibGV0w6ZydGUK:"],
+        "header_type": "dictionary",
+        "expected": {"en": ["Applepie", {}], "da": [
+            {"__type": "binary", "value": "YODGE3DFOTB2M4TUMUFA===="},
+            {}]
+        }
     },
     {
-      "name": "empty dictionary",
-      "raw": [""],
-      "header_type": "dictionary",
-      "expected": {},
-      "canonical": []
+        "name": "empty dictionary",
+        "raw": [""],
+        "header_type": "dictionary",
+        "expected": {},
+        "canonical": []
     },
     {
-      "name": "single item dictionary",
-      "raw": ["a=1"],
-      "header_type": "dictionary",
-      "expected": {"a": [1, {}]}
+        "name": "single item dictionary",
+        "raw": ["a=1"],
+        "header_type": "dictionary",
+        "expected": {"a": [1, {}]}
     },
     {
-      "name": "list item dictionary",
-      "raw": ["a=(1 2)"],
-      "header_type": "dictionary",
-      "expected": {"a": [[[1, {}], [2, {}]], {}]}
+        "name": "list item dictionary",
+        "raw": ["a=(1 2)"],
+        "header_type": "dictionary",
+        "expected": {"a": [[[1, {}], [2, {}]], {}]}
     },
     {
-      "name": "single list item dictionary",
-      "raw": ["a=(1)"],
-      "header_type": "dictionary",
-      "expected": {"a": [[[1, {}]], {}]}
+        "name": "single list item dictionary",
+        "raw": ["a=(1)"],
+        "header_type": "dictionary",
+        "expected": {"a": [[[1, {}]], {}]}
     },
     {
-      "name": "empty list item dictionary",
-      "raw": ["a=()"],
-      "header_type": "dictionary",
-      "expected": {"a": [[], {}]}
+        "name": "empty list item dictionary",
+        "raw": ["a=()"],
+        "header_type": "dictionary",
+        "expected": {"a": [[], {}]}
     },
     {
-      "name": "no whitespace dictionary",
-      "raw": ["a=1,b=2"],
-      "header_type": "dictionary",
-      "expected": {"a": [1, {}], "b": [2, {}]},
-      "canonical": ["a=1, b=2"]
+        "name": "no whitespace dictionary",
+        "raw": ["a=1,b=2"],
+        "header_type": "dictionary",
+        "expected": {"a": [1, {}], "b": [2, {}]},
+        "canonical": ["a=1, b=2"]
     },
     {
-      "name": "extra whitespace dictionary",
-      "raw": ["a=1 ,  b=2"],
-      "header_type": "dictionary",
-      "expected": {"a": [1, {}], "b": [2, {}]},
-      "canonical": ["a=1, b=2"]
+        "name": "extra whitespace dictionary",
+        "raw": ["a=1 ,  b=2"],
+        "header_type": "dictionary",
+        "expected": {"a": [1, {}], "b": [2, {}]},
+        "canonical": ["a=1, b=2"]
     },
     {
-      "name": "tab separated dictionary",
-      "raw": ["a=1\t,\tb=2"],
-      "header_type": "dictionary",
-      "expected": {"a": [1, {}], "b": [2, {}]},
-      "canonical": ["a=1, b=2"]
+        "name": "tab separated dictionary",
+        "raw": ["a=1\t,\tb=2"],
+        "header_type": "dictionary",
+        "expected": {"a": [1, {}], "b": [2, {}]},
+        "canonical": ["a=1, b=2"]
     },
     {
-      "name": "leading whitespace dictionary",
-      "raw": ["     a=1 ,  b=2"],
-      "header_type": "dictionary",
-      "expected": {"a": [1, {}], "b": [2, {}]},
-      "canonical": ["a=1, b=2"]
+        "name": "leading whitespace dictionary",
+        "raw": ["     a=1 ,  b=2"],
+        "header_type": "dictionary",
+        "expected": {"a": [1, {}], "b": [2, {}]},
+        "canonical": ["a=1, b=2"]
     },
     {
-      "name": "whitespace before = dictionary",
-      "raw": ["a =1, b=2"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "whitespace before = dictionary",
+        "raw": ["a =1, b=2"],
+        "header_type": "dictionary",
+        "must_fail": true
     },
     {
-      "name": "whitespace after = dictionary",
-      "raw": ["a=1, b= 2"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "whitespace after = dictionary",
+        "raw": ["a=1, b= 2"],
+        "header_type": "dictionary",
+        "must_fail": true
     },
     {
-      "name": "two lines dictionary",
-      "raw": ["a=1", "b=2"],
-      "header_type": "dictionary",
-      "expected": {"a": [1, {}], "b": [2, {}]},
-      "canonical": ["a=1, b=2"]
+        "name": "two lines dictionary",
+        "raw": ["a=1", "b=2"],
+        "header_type": "dictionary",
+        "expected": {"a": [1, {}], "b": [2, {}]},
+        "canonical": ["a=1, b=2"]
     },
     {
-      "name": "missing value dictionary",
-      "raw": ["a=1, b, c=3"],
-      "header_type": "dictionary",
-      "expected": {"a": [1,{}], "b": [true, {}], "c": [3, {}]}
+        "name": "missing value dictionary",
+        "raw": ["a=1, b, c=3"],
+        "header_type": "dictionary",
+        "expected": {"a": [1,{}], "b": [true, {}], "c": [3, {}]}
     },
     {
-      "name": "all missing value dictionary",
-      "raw": ["a, b, c"],
-      "header_type": "dictionary",
-      "expected": {"a": [true,{}], "b": [true, {}], "c": [true, {}]}
+        "name": "all missing value dictionary",
+        "raw": ["a, b, c"],
+        "header_type": "dictionary",
+        "expected": {"a": [true,{}], "b": [true, {}], "c": [true, {}]}
     },
     {
-      "name": "start missing value dictionary",
-      "raw": ["a, b=2"],
-      "header_type": "dictionary",
-      "expected": {"a": [true,{}], "b": [2, {}]}
+        "name": "start missing value dictionary",
+        "raw": ["a, b=2"],
+        "header_type": "dictionary",
+        "expected": {"a": [true,{}], "b": [2, {}]}
     },
     {
-      "name": "end missing value dictionary",
-      "raw": ["a=1, b"],
-      "header_type": "dictionary",
-      "expected": {"a": [1,{}], "b": [true, {}]}
+        "name": "end missing value dictionary",
+        "raw": ["a=1, b"],
+        "header_type": "dictionary",
+        "expected": {"a": [1,{}], "b": [true, {}]}
     },
     {
-      "name": "missing value with params dictionary",
-      "raw": ["a=1, b;foo=9, c=3"],
-      "header_type": "dictionary",
-      "expected": {"a": [1,{}], "b": [true, {"foo": 9}], "c": [3, {}]}
+        "name": "missing value with params dictionary",
+        "raw": ["a=1, b;foo=9, c=3"],
+        "header_type": "dictionary",
+        "expected": {"a": [1,{}], "b": [true, {"foo": 9}], "c": [3, {}]}
     },
     {
-      "name": "explicit true value with params dictionary",
-      "raw": ["a=1, b=?1;foo=9, c=3"],
-      "header_type": "dictionary",
-      "expected": {"a": [1,{}], "b": [true, {"foo": 9}], "c": [3, {}]},
-      "canonical": ["a=1, b;foo=9, c=3"]
+        "name": "explicit true value with params dictionary",
+        "raw": ["a=1, b=?1;foo=9, c=3"],
+        "header_type": "dictionary",
+        "expected": {"a": [1,{}], "b": [true, {"foo": 9}], "c": [3, {}]},
+        "canonical": ["a=1, b;foo=9, c=3"]
     },
     {
-      "name": "trailing comma dictionary",
-      "raw": ["a=1, b=2,"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "trailing comma dictionary",
+        "raw": ["a=1, b=2,"],
+        "header_type": "dictionary",
+        "must_fail": true
     },
     {
-      "name": "empty item dictionary",
-      "raw": ["a=1,,b=2,"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "empty item dictionary",
+        "raw": ["a=1,,b=2,"],
+        "header_type": "dictionary",
+        "must_fail": true
     },
     {
-      "name": "duplicate key dictionary",
-      "raw": ["a=1,b=2,a=3"],
-      "header_type": "dictionary",
-      "expected": {"a": [3, {}], "b": [2, {}]},
-      "canonical": ["a=3, b=2"]
+        "name": "duplicate key dictionary",
+        "raw": ["a=1,b=2,a=3"],
+        "header_type": "dictionary",
+        "expected": {"a": [3, {}], "b": [2, {}]},
+        "canonical": ["a=3, b=2"]
     },
     {
-      "name": "numeric key dictionary",
-      "raw": ["a=1,1b=2,a=1"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "numeric key dictionary",
+        "raw": ["a=1,1b=2,a=1"],
+        "header_type": "dictionary",
+        "must_fail": true
     },
     {
-      "name": "uppercase key dictionary",
-      "raw": ["a=1,B=2,a=1"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "uppercase key dictionary",
+        "raw": ["a=1,B=2,a=1"],
+        "header_type": "dictionary",
+        "must_fail": true
     },
     {
-      "name": "bad key dictionary",
-      "raw": ["a=1,b!=2,a=1"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "bad key dictionary",
+        "raw": ["a=1,b!=2,a=1"],
+        "header_type": "dictionary",
+        "must_fail": true
     }
 ]

--- a/examples.json
+++ b/examples.json
@@ -1,206 +1,206 @@
 [
-  {
-    "name": "Foo-Example",
-    "raw": ["2; foourl=\"https://foo.example.com/\""],
-    "header_type": "item",
-    "expected": [2, {"foourl": "https://foo.example.com/"}],
-    "canonical": ["2;foourl=\"https://foo.example.com/\""]
-  },
-  {
-    "name": "Example-StrListHeader",
-    "raw": ["\"foo\", \"bar\", \"It was the best of times.\""],
-    "header_type": "list",
-    "expected": [
-      ["foo", {}],
-      ["bar", {}],
-      ["It was the best of times.", {}]
-    ]
-  },
-  {
-    "name": "Example-Hdr (list on one line)",
-    "raw": ["foo, bar"],
-    "header_type": "list",
-    "expected": [
-      [{"__type":"token", "value":"foo"}, {}],
-      [{"__type":"token", "value":"bar"}, {}]
-    ]
-  },
-  {
-    "name": "Example-Hdr (list on two lines)",
-    "raw": ["foo", "bar"],
-    "header_type": "list",
-    "expected": [
-      [{"__type":"token", "value":"foo"}, {}],
-      [{"__type":"token", "value":"bar"}, {}]
-    ],
-    "canonical": ["foo, bar"]
-  },
-  {
-    "name": "Example-StrListListHeader",
-    "raw": ["(\"foo\" \"bar\"), (\"baz\"), (\"bat\" \"one\"), ()"],
-    "header_type": "list",
-    "expected": [
-      [[
-        ["foo", {}],
-        ["bar", {}]
-      ], {}],
-      [[
-        ["baz", {}]
-      ], {}],
-      [[
-        ["bat", {}],
-        ["one", {}]
-      ], {}],
-      [[], {}]
-    ]
-  },
-  {
-    "name": "Example-ListListParam",
-    "raw": ["(\"foo\"; a=1;b=2);lvl=5, (\"bar\" \"baz\");lvl=1"],
-    "header_type": "list",
-    "expected": [
-      [[
-          ["foo", {"a": 1, "b": 2}]
-      ], {"lvl": 5}],
-      [[
-          ["bar", {}], ["baz", {}]
-      ], {"lvl": 1}]
-    ],
-    "canonical": ["(\"foo\";a=1;b=2);lvl=5, (\"bar\" \"baz\");lvl=1"]
-  },
-
-  {
-    "name": "Example-ParamListHeader",
-    "raw": ["abc;a=1;b=2; cde_456, (ghi;jk=4 l);q=\"9\";r=w"],
-    "header_type": "list",
-    "expected": [
-      [{"__type": "token", "value": "abc"}, {"a": 1, "b": 2, "cde_456": true}],
-      [
-        [
-          [{"__type": "token", "value": "ghi"}, {"jk": 4}],
-          [{"__type": "token", "value": "l"}, {}]
+    {
+        "name": "Foo-Example",
+        "raw": ["2; foourl=\"https://foo.example.com/\""],
+        "header_type": "item",
+        "expected": [2, {"foourl": "https://foo.example.com/"}],
+        "canonical": ["2;foourl=\"https://foo.example.com/\""]
+    },
+    {
+        "name": "Example-StrListHeader",
+        "raw": ["\"foo\", \"bar\", \"It was the best of times.\""],
+        "header_type": "list",
+        "expected": [
+            ["foo", {}],
+            ["bar", {}],
+            ["It was the best of times.", {}]
+        ]
+    },
+    {
+        "name": "Example-Hdr (list on one line)",
+        "raw": ["foo, bar"],
+        "header_type": "list",
+        "expected": [
+            [{"__type":"token", "value":"foo"}, {}],
+            [{"__type":"token", "value":"bar"}, {}]
+        ]
+    },
+    {
+        "name": "Example-Hdr (list on two lines)",
+        "raw": ["foo", "bar"],
+        "header_type": "list",
+        "expected": [
+            [{"__type":"token", "value":"foo"}, {}],
+            [{"__type":"token", "value":"bar"}, {}]
         ],
-        {"q": "9", "r": {"__type": "token", "value": "w"}}
-      ]
-    ],
-    "canonical": ["abc;a=1;b=2;cde_456, (ghi;jk=4 l);q=\"9\";r=w"]
-  },
-  {
-      "name": "Example-IntHeader",
-      "raw": ["1; a; b=?0"],
-      "header_type": "item",
-      "expected": [1, {"a": true, "b": false}],
-      "canonical": ["1;a;b=?0"]
-  },
-  {
-    "name": "Example-DictHeader",
-    "raw": ["en=\"Applepie\", da=:w4ZibGV0w6ZydGU=:"],
-    "header_type": "dictionary",
-    "expected": {
-      "en": ["Applepie", {}],
-      "da": [{"__type": "binary", "value": "YODGE3DFOTB2M4TUMU======"}, {}]
-    }
-  },
-  {
-      "name": "Example-DictHeader",
-      "raw": ["a=?0, b, c; foo=bar"],
-      "header_type": "dictionary",
-      "expected": {"a": [false, {}], "b": [true, {}], "c": [
-          true, {"foo": {"__type": "token", "value": "bar"}}
-      ]},
-      "canonical": ["a=?0, b, c;foo=bar"]
-  },
-  {
-    "name": "Example-DictListHeader",
-    "raw": ["rating=1.5, feelings=(joy sadness)"],
-    "header_type": "dictionary",
-    "expected": {
-      "rating": [1.5, {}],
-      "feelings": [[
-        [{"__type": "token", "value": "joy"}, {}],
-        [{"__type": "token", "value": "sadness"}, {}]
-      ], {}]
-    }
-  },
-  {
-    "name": "Example-MixDict",
-    "raw": ["a=(1 2), b=3, c=4;aa=bb, d=(5 6);valid"],
-    "header_type": "dictionary",
-    "expected": {
-      "a": [[
-        [1, {}],
-        [2, {}]
-      ], {}],
-      "b": [3, {}],
-      "c": [4, {"aa": {"__type": "token", "value": "bb"}}],
-      "d": [[
-        [5, {}],
-        [6, {}]
-      ], {"valid": true}]
+        "canonical": ["foo, bar"]
     },
-    "canonical": ["a=(1 2), b=3, c=4;aa=bb, d=(5 6);valid"]
-  },
-  {
-    "name": "Example-Hdr (dictionary on one line)",
-    "raw": ["foo=1, bar=2"],
-    "header_type": "dictionary",
-    "expected": {
-      "foo": [1, {}],
-      "bar": [2, {}]
-    }
-  },
-  {
-    "name": "Example-Hdr (dictionary on two lines)",
-    "raw": ["foo=1", "bar=2"],
-    "header_type": "dictionary",
-    "expected": {
-      "foo": [1, {}],
-      "bar": [2, {}]
+    {
+        "name": "Example-StrListListHeader",
+        "raw": ["(\"foo\" \"bar\"), (\"baz\"), (\"bat\" \"one\"), ()"],
+        "header_type": "list",
+        "expected": [
+            [[
+                ["foo", {}],
+                ["bar", {}]
+            ], {}],
+            [[
+                ["baz", {}]
+            ], {}],
+            [[
+                ["bat", {}],
+                ["one", {}]
+            ], {}],
+            [[], {}]
+        ]
     },
-    "canonical": ["foo=1, bar=2"]
-  },
+    {
+        "name": "Example-ListListParam",
+        "raw": ["(\"foo\"; a=1;b=2);lvl=5, (\"bar\" \"baz\");lvl=1"],
+        "header_type": "list",
+        "expected": [
+            [[
+                ["foo", {"a": 1, "b": 2}]
+            ], {"lvl": 5}],
+            [[
+                ["bar", {}], ["baz", {}]
+            ], {"lvl": 1}]
+        ],
+        "canonical": ["(\"foo\";a=1;b=2);lvl=5, (\"bar\" \"baz\");lvl=1"]
+    },
 
-  {
-    "name": "Example-IntItemHeader",
-    "raw": ["5"],
-    "header_type": "item",
-    "expected": [5, {}]
-  },
-  {
-    "name": "Example-IntItemHeader (params)",
-    "raw": ["5; foo=bar"],
-    "header_type": "item",
-    "expected": [5, {"foo": {"__type": "token", "value": "bar"}}],
-    "canonical": ["5;foo=bar"]
-  },
-  {
-    "name": "Example-IntegerHeader",
-    "raw": ["42"],
-    "header_type": "item",
-    "expected": [42, {}]
-  },
-  {
-    "name": "Example-FloatHeader",
-    "raw": ["4.5"],
-    "header_type": "item",
-    "expected": [4.5, {}]
-  },
-  {
-    "name": "Example-StringHeader",
-    "raw": ["\"hello world\""],
-    "header_type": "item",
-    "expected": ["hello world", {}]
-  },
-  {
-    "name": "Example-BinaryHdr",
-    "raw": [":cHJldGVuZCB0aGlzIGlzIGJpbmFyeSBjb250ZW50Lg==:"],
-    "header_type": "item",
-    "expected": [{"__type": "binary", "value": "OBZGK5DFNZSCA5DINFZSA2LTEBRGS3TBOJ4SAY3PNZ2GK3TUFY======"}, {}]
-  },
-  {
-    "name": "Example-BoolHdr",
-    "raw": ["?1"],
-    "header_type": "item",
-    "expected": [true, {}]
-  }
+    {
+        "name": "Example-ParamListHeader",
+        "raw": ["abc;a=1;b=2; cde_456, (ghi;jk=4 l);q=\"9\";r=w"],
+        "header_type": "list",
+        "expected": [
+            [{"__type": "token", "value": "abc"}, {"a": 1, "b": 2, "cde_456": true}],
+            [
+            [
+                [{"__type": "token", "value": "ghi"}, {"jk": 4}],
+                [{"__type": "token", "value": "l"}, {}]
+            ],
+            {"q": "9", "r": {"__type": "token", "value": "w"}}
+            ]
+        ],
+        "canonical": ["abc;a=1;b=2;cde_456, (ghi;jk=4 l);q=\"9\";r=w"]
+    },
+    {
+        "name": "Example-IntHeader",
+        "raw": ["1; a; b=?0"],
+        "header_type": "item",
+        "expected": [1, {"a": true, "b": false}],
+        "canonical": ["1;a;b=?0"]
+    },
+    {
+        "name": "Example-DictHeader",
+        "raw": ["en=\"Applepie\", da=:w4ZibGV0w6ZydGU=:"],
+        "header_type": "dictionary",
+        "expected": {
+            "en": ["Applepie", {}],
+            "da": [{"__type": "binary", "value": "YODGE3DFOTB2M4TUMU======"}, {}]
+        }
+    },
+    {
+        "name": "Example-DictHeader",
+        "raw": ["a=?0, b, c; foo=bar"],
+        "header_type": "dictionary",
+        "expected": {"a": [false, {}], "b": [true, {}], "c": [
+            true, {"foo": {"__type": "token", "value": "bar"}}
+        ]},
+        "canonical": ["a=?0, b, c;foo=bar"]
+    },
+    {
+        "name": "Example-DictListHeader",
+        "raw": ["rating=1.5, feelings=(joy sadness)"],
+        "header_type": "dictionary",
+        "expected": {
+            "rating": [1.5, {}],
+            "feelings": [[
+                [{"__type": "token", "value": "joy"}, {}],
+                [{"__type": "token", "value": "sadness"}, {}]
+            ], {}]
+        }
+    },
+    {
+        "name": "Example-MixDict",
+        "raw": ["a=(1 2), b=3, c=4;aa=bb, d=(5 6);valid"],
+        "header_type": "dictionary",
+        "expected": {
+            "a": [[
+                [1, {}],
+                [2, {}]
+            ], {}],
+            "b": [3, {}],
+            "c": [4, {"aa": {"__type": "token", "value": "bb"}}],
+            "d": [[
+                [5, {}],
+                [6, {}]
+            ], {"valid": true}]
+        },
+        "canonical": ["a=(1 2), b=3, c=4;aa=bb, d=(5 6);valid"]
+    },
+    {
+        "name": "Example-Hdr (dictionary on one line)",
+        "raw": ["foo=1, bar=2"],
+        "header_type": "dictionary",
+        "expected": {
+            "foo": [1, {}],
+            "bar": [2, {}]
+        }
+    },
+    {
+        "name": "Example-Hdr (dictionary on two lines)",
+        "raw": ["foo=1", "bar=2"],
+        "header_type": "dictionary",
+        "expected": {
+            "foo": [1, {}],
+            "bar": [2, {}]
+        },
+        "canonical": ["foo=1, bar=2"]
+    },
+
+    {
+        "name": "Example-IntItemHeader",
+        "raw": ["5"],
+        "header_type": "item",
+        "expected": [5, {}]
+    },
+    {
+        "name": "Example-IntItemHeader (params)",
+        "raw": ["5; foo=bar"],
+        "header_type": "item",
+        "expected": [5, {"foo": {"__type": "token", "value": "bar"}}],
+        "canonical": ["5;foo=bar"]
+    },
+    {
+        "name": "Example-IntegerHeader",
+        "raw": ["42"],
+        "header_type": "item",
+        "expected": [42, {}]
+    },
+    {
+        "name": "Example-FloatHeader",
+        "raw": ["4.5"],
+        "header_type": "item",
+        "expected": [4.5, {}]
+    },
+    {
+        "name": "Example-StringHeader",
+        "raw": ["\"hello world\""],
+        "header_type": "item",
+        "expected": ["hello world", {}]
+    },
+    {
+        "name": "Example-BinaryHdr",
+        "raw": [":cHJldGVuZCB0aGlzIGlzIGJpbmFyeSBjb250ZW50Lg==:"],
+        "header_type": "item",
+        "expected": [{"__type": "binary", "value": "OBZGK5DFNZSCA5DINFZSA2LTEBRGS3TBOJ4SAY3PNZ2GK3TUFY======"}, {}]
+    },
+    {
+        "name": "Example-BoolHdr",
+        "raw": ["?1"],
+        "header_type": "item",
+        "expected": [true, {}]
+    }
 ]

--- a/item.json
+++ b/item.json
@@ -1,34 +1,34 @@
 [
     {
-      "name": "empty item",
-      "raw": [""],
-      "header_type": "item",
-      "must_fail": true
+        "name": "empty item",
+        "raw": [""],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "leading space",
-      "raw": [" \t 1"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "leading space",
+        "raw": [" \t 1"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "trailing space",
-      "raw": ["1 \t "],
-      "header_type": "item",
-      "must_fail": true
+        "name": "trailing space",
+        "raw": ["1 \t "],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "leading and trailing space",
-      "raw": ["  1  "],
-      "header_type": "item",
-      "expected": [1, {}],
-      "canonical": ["1"]
+        "name": "leading and trailing space",
+        "raw": ["  1  "],
+        "header_type": "item",
+        "expected": [1, {}],
+        "canonical": ["1"]
     },
     {
-      "name": "leading and trailing whitespace",
-      "raw": ["     1  "],
-      "header_type": "item",
-      "expected": [1, {}],
-      "canonical": ["1"]
+        "name": "leading and trailing whitespace",
+        "raw": ["     1  "],
+        "header_type": "item",
+        "expected": [1, {}],
+        "canonical": ["1"]
     }
 ]

--- a/list.json
+++ b/list.json
@@ -1,68 +1,68 @@
 [
     {
-      "name": "basic list",
-      "raw": ["1, 42"],
-      "header_type": "list",
-      "expected": [[1, {}], [42, {}]]
+        "name": "basic list",
+        "raw": ["1, 42"],
+        "header_type": "list",
+        "expected": [[1, {}], [42, {}]]
     },
     {
-      "name": "empty list",
-      "raw": [""],
-      "header_type": "list",
-      "expected": [],
-      "canonical": []
+        "name": "empty list",
+        "raw": [""],
+        "header_type": "list",
+        "expected": [],
+        "canonical": []
     },
     {
-      "name": "leading SP list",
-      "raw": ["  42, 43"],
-      "canonical": ["42, 43"],
-      "header_type": "list",
-      "expected": [[42, {}], [43, {}]]
+        "name": "leading SP list",
+        "raw": ["  42, 43"],
+        "canonical": ["42, 43"],
+        "header_type": "list",
+        "expected": [[42, {}], [43, {}]]
     },
     {
-      "name": "single item list",
-      "raw": ["42"],
-      "header_type": "list",
-      "expected": [[42, {}]]
+        "name": "single item list",
+        "raw": ["42"],
+        "header_type": "list",
+        "expected": [[42, {}]]
     },
     {
-      "name": "no whitespace list",
-      "raw": ["1,42"],
-      "header_type": "list",
-      "expected": [[1, {}], [42, {}]],
-      "canonical": ["1, 42"]
+        "name": "no whitespace list",
+        "raw": ["1,42"],
+        "header_type": "list",
+        "expected": [[1, {}], [42, {}]],
+        "canonical": ["1, 42"]
     },
     {
-      "name": "extra whitespace list",
-      "raw": ["1 , 42"],
-      "header_type": "list",
-      "expected": [[1, {}], [42, {}]],
-      "canonical": ["1, 42"]
+        "name": "extra whitespace list",
+        "raw": ["1 , 42"],
+        "header_type": "list",
+        "expected": [[1, {}], [42, {}]],
+        "canonical": ["1, 42"]
     },
     {
-      "name": "tab separated list",
-      "raw": ["1\t,\t42"],
-      "header_type": "list",
-      "expected": [[1, {}], [42, {}]],
-      "canonical": ["1, 42"]
+        "name": "tab separated list",
+        "raw": ["1\t,\t42"],
+        "header_type": "list",
+        "expected": [[1, {}], [42, {}]],
+        "canonical": ["1, 42"]
     },
     {
-      "name": "two line list",
-      "raw": ["1", "42"],
-      "header_type": "list",
-      "expected": [[1, {}], [42, {}]],
-      "canonical": ["1, 42"]
+        "name": "two line list",
+        "raw": ["1", "42"],
+        "header_type": "list",
+        "expected": [[1, {}], [42, {}]],
+        "canonical": ["1, 42"]
     },
     {
-      "name": "trailing comma list",
-      "raw": ["1, 42,"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "trailing comma list",
+        "raw": ["1, 42,"],
+        "header_type": "list",
+        "must_fail": true
     },
     {
-      "name": "empty item list",
-      "raw": ["1,,42"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "empty item list",
+        "raw": ["1,,42"],
+        "header_type": "list",
+        "must_fail": true
     }
 ]

--- a/listlist.json
+++ b/listlist.json
@@ -1,58 +1,58 @@
 [
     {
-      "name": "basic list of lists",
-      "raw": ["(1 2), (42 43)"],
-      "header_type": "list",
-      "expected": [[[[1,{}], [2,{}]], {}], [[[42,{}], [43,{}]], {}]]
+        "name": "basic list of lists",
+        "raw": ["(1 2), (42 43)"],
+        "header_type": "list",
+        "expected": [[[[1,{}], [2,{}]], {}], [[[42,{}], [43,{}]], {}]]
     },
     {
-      "name": "single item list of lists",
-      "raw": ["(42)"],
-      "header_type": "list",
-      "expected": [[[[42,{}]], {}]]
+        "name": "single item list of lists",
+        "raw": ["(42)"],
+        "header_type": "list",
+        "expected": [[[[42,{}]], {}]]
     },
     {
-      "name": "empty item list of lists",
-      "raw": ["()"],
-      "header_type": "list",
-      "expected": [[[], {}]]
+        "name": "empty item list of lists",
+        "raw": ["()"],
+        "header_type": "list",
+        "expected": [[[], {}]]
     },
     {
-      "name": "empty middle item list of lists",
-      "raw": ["(1),(),(42)"],
-      "header_type": "list",
-      "expected": [[[[1,{}]], {}], [[], {}], [[[42,{}]], {}]],
-      "canonical": ["(1), (), (42)"]
+        "name": "empty middle item list of lists",
+        "raw": ["(1),(),(42)"],
+        "header_type": "list",
+        "expected": [[[[1,{}]], {}], [[], {}], [[[42,{}]], {}]],
+        "canonical": ["(1), (), (42)"]
     },
     {
-      "name": "extra whitespace list of lists",
-      "raw": ["(  1  42  )"],
-      "header_type": "list",
-      "expected": [[[[1,{}], [42,{}]], {}]],
-      "canonical": ["(1 42)"]
+        "name": "extra whitespace list of lists",
+        "raw": ["(  1  42  )"],
+        "header_type": "list",
+        "expected": [[[[1,{}], [42,{}]], {}]],
+        "canonical": ["(1 42)"]
     },
     {
-      "name": "wrong whitespace list of lists",
-      "raw": ["(1\t 42)"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "wrong whitespace list of lists",
+        "raw": ["(1\t 42)"],
+        "header_type": "list",
+        "must_fail": true
     },
     {
-      "name": "no trailing parenthesis list of lists",
-      "raw": ["(1 42"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "no trailing parenthesis list of lists",
+        "raw": ["(1 42"],
+        "header_type": "list",
+        "must_fail": true
     },
     {
-      "name": "no trailing parenthesis middle list of lists",
-      "raw": ["(1 2, (42 43)"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "no trailing parenthesis middle list of lists",
+        "raw": ["(1 2, (42 43)"],
+        "header_type": "list",
+        "must_fail": true
     },
     {
-      "name": "no spaces in inner-list",
-      "raw": ["(abc\"def\"?0123*dXZ3*xyz)"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "no spaces in inner-list",
+        "raw": ["(abc\"def\"?0123*dXZ3*xyz)"],
+        "header_type": "list",
+        "must_fail": true
     }
 ]

--- a/number.json
+++ b/number.json
@@ -1,193 +1,193 @@
 [
     {
-      "name": "basic integer",
-      "raw": ["42"],
-      "header_type": "item",
-      "expected": [42, {}]
+        "name": "basic integer",
+        "raw": ["42"],
+        "header_type": "item",
+        "expected": [42, {}]
     },
     {
-      "name": "zero integer",
-      "raw": ["0"],
-      "header_type": "item",
-      "expected": [0, {}]
+        "name": "zero integer",
+        "raw": ["0"],
+        "header_type": "item",
+        "expected": [0, {}]
     },
     {
-      "name": "leading 0 zero",
-      "raw": ["00"],
-      "header_type": "item",
-      "expected": [0, {}],
-      "canonical": ["0"]
+        "name": "leading 0 zero",
+        "raw": ["00"],
+        "header_type": "item",
+        "expected": [0, {}],
+        "canonical": ["0"]
     },
     {
-      "name": "negative zero",
-      "raw": ["-0"],
-      "header_type": "item",
-      "expected": [0, {}],
-      "canonical": ["0"]
+        "name": "negative zero",
+        "raw": ["-0"],
+        "header_type": "item",
+        "expected": [0, {}],
+        "canonical": ["0"]
     },
     {
-      "name": "double negative zero",
-      "raw": ["--0"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "double negative zero",
+        "raw": ["--0"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "negative integer",
-      "raw": ["-42"],
-      "header_type": "item",
-      "expected": [-42, {}]
+        "name": "negative integer",
+        "raw": ["-42"],
+        "header_type": "item",
+        "expected": [-42, {}]
     },
     {
-      "name": "leading 0 integer",
-      "raw": ["042"],
-      "header_type": "item",
-      "expected": [42, {}],
-      "canonical": ["42"]
+        "name": "leading 0 integer",
+        "raw": ["042"],
+        "header_type": "item",
+        "expected": [42, {}],
+        "canonical": ["42"]
     },
     {
-      "name": "leading 0 negative integer",
-      "raw": ["-042"],
-      "header_type": "item",
-      "expected": [-42, {}],
-      "canonical": ["-42"]
+        "name": "leading 0 negative integer",
+        "raw": ["-042"],
+        "header_type": "item",
+        "expected": [-42, {}],
+        "canonical": ["-42"]
     },
     {
-      "name": "leading 0 zero",
-      "raw": ["00"],
-      "header_type": "item",
-      "expected": [0, {}],
-      "canonical": ["0"]
+        "name": "leading 0 zero",
+        "raw": ["00"],
+        "header_type": "item",
+        "expected": [0, {}],
+        "canonical": ["0"]
     },
     {
-      "name": "comma",
-      "raw": ["2,3"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "comma",
+        "raw": ["2,3"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "negative non-DIGIT first character",
-      "raw": ["-a23"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "negative non-DIGIT first character",
+        "raw": ["-a23"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "sign out of place",
-      "raw": ["4-2"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "sign out of place",
+        "raw": ["4-2"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "whitespace after sign",
-      "raw": ["- 42"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "whitespace after sign",
+        "raw": ["- 42"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "long integer",
-      "raw": ["123456789012345"],
-      "header_type": "item",
-      "expected": [123456789012345, {}]
+        "name": "long integer",
+        "raw": ["123456789012345"],
+        "header_type": "item",
+        "expected": [123456789012345, {}]
     },
     {
-      "name": "long negative integer",
-      "raw": ["-123456789012345"],
-      "header_type": "item",
-      "expected": [-123456789012345, {}]
+        "name": "long negative integer",
+        "raw": ["-123456789012345"],
+        "header_type": "item",
+        "expected": [-123456789012345, {}]
     },
     {
-      "name": "too long integer",
-      "raw": ["1234567890123456"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "too long integer",
+        "raw": ["1234567890123456"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "negative too long integer",
-      "raw": ["-1234567890123456"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "negative too long integer",
+        "raw": ["-1234567890123456"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "simple decimal",
-      "raw": ["1.23"],
-      "header_type": "item",
-      "expected": [1.23, {}]
+        "name": "simple decimal",
+        "raw": ["1.23"],
+        "header_type": "item",
+        "expected": [1.23, {}]
     },
     {
-      "name": "negative decimal",
-      "raw": ["-1.23"],
-      "header_type": "item",
-      "expected": [-1.23, {}]
+        "name": "negative decimal",
+        "raw": ["-1.23"],
+        "header_type": "item",
+        "expected": [-1.23, {}]
     },
     {
-      "name": "decimal, whitespace after decimal",
-      "raw": ["1. 23"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "decimal, whitespace after decimal",
+        "raw": ["1. 23"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "decimal, whitespace before decimal",
-      "raw": ["1 .23"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "decimal, whitespace before decimal",
+        "raw": ["1 .23"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "negative decimal, whitespace after sign",
-      "raw": ["- 1.23"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "negative decimal, whitespace after sign",
+        "raw": ["- 1.23"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "tricky precision decimal",
-      "raw": ["123456789012.1"],
-      "header_type": "item",
-      "expected": [123456789012.1, {}]
+        "name": "tricky precision decimal",
+        "raw": ["123456789012.1"],
+        "header_type": "item",
+        "expected": [123456789012.1, {}]
     },
     {
-      "name": "double decimal decimal",
-      "raw": ["1.5.4"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "double decimal decimal",
+        "raw": ["1.5.4"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "adjacent double decimal decimal",
-      "raw": ["1..4"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "adjacent double decimal decimal",
+        "raw": ["1..4"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "decimal with three fractional digits",
-      "raw": ["1.123"],
-      "header_type": "item",
-      "expected": [1.123, {}]
+        "name": "decimal with three fractional digits",
+        "raw": ["1.123"],
+        "header_type": "item",
+        "expected": [1.123, {}]
     },
     {
-      "name": "negative decimal with three fractional digits",
-      "raw": ["-1.123"],
-      "header_type": "item",
-      "expected": [-1.123, {}]
+        "name": "negative decimal with three fractional digits",
+        "raw": ["-1.123"],
+        "header_type": "item",
+        "expected": [-1.123, {}]
     },
     {
-      "name": "decimal with four fractional digits",
-      "raw": ["1.1234"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "decimal with four fractional digits",
+        "raw": ["1.1234"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "negative decimal with four fractional digits",
-      "raw": ["-1.1234"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "negative decimal with four fractional digits",
+        "raw": ["-1.1234"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "decimal with thirteen integer digits",
-      "raw": ["1234567890123.0"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "decimal with thirteen integer digits",
+        "raw": ["1234567890123.0"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "negative decimal with thirteen integer digits",
-      "raw": ["-1234567890123.0"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "negative decimal with thirteen integer digits",
+        "raw": ["-1234567890123.0"],
+        "header_type": "item",
+        "must_fail": true
     }
 ]

--- a/param-dict.json
+++ b/param-dict.json
@@ -1,113 +1,113 @@
 [
     {
-      "name": "basic parameterised dict",
-      "raw": ["abc=123;a=1;b=2, def=456, ghi=789;q=9;r=\"+w\""],
-      "header_type": "dictionary",
-      "expected": {
-        "abc": [123, {"a": 1, "b": 2}],
-        "def": [456, {}],
-        "ghi": [789, {"q": 9, "r": "+w"}]
-      }
+        "name": "basic parameterised dict",
+        "raw": ["abc=123;a=1;b=2, def=456, ghi=789;q=9;r=\"+w\""],
+        "header_type": "dictionary",
+        "expected": {
+            "abc": [123, {"a": 1, "b": 2}],
+            "def": [456, {}],
+            "ghi": [789, {"q": 9, "r": "+w"}]
+        }
     },
     {
-      "name": "single item parameterised dict",
-      "raw": ["a=b; q=1.0"],
-      "header_type": "dictionary",
-      "expected": {
-          "a": [{"__type": "token", "value": "b"}, {"q": 1.0}]
-      },
-      "canonical": ["a=b;q=1.0"]
+        "name": "single item parameterised dict",
+        "raw": ["a=b; q=1.0"],
+        "header_type": "dictionary",
+        "expected": {
+            "a": [{"__type": "token", "value": "b"}, {"q": 1.0}]
+        },
+        "canonical": ["a=b;q=1.0"]
     },
     {
-      "name": "list item parameterised dictionary",
-      "raw": ["a=(1 2); q=1.0"],
-      "header_type": "dictionary",
-      "expected": {"a": [[[1, {}], [2, {}]], {"q": 1.0}]},
-      "canonical": ["a=(1 2);q=1.0"]
+        "name": "list item parameterised dictionary",
+        "raw": ["a=(1 2); q=1.0"],
+        "header_type": "dictionary",
+        "expected": {"a": [[[1, {}], [2, {}]], {"q": 1.0}]},
+        "canonical": ["a=(1 2);q=1.0"]
     },
     {
-      "name": "missing parameter value parameterised dict",
-      "raw": ["a=3;c;d=5"],
-      "header_type": "dictionary",
-      "expected": {
-          "a": [3, {"c": true, "d": 5}]
-      }
+        "name": "missing parameter value parameterised dict",
+        "raw": ["a=3;c;d=5"],
+        "header_type": "dictionary",
+        "expected": {
+            "a": [3, {"c": true, "d": 5}]
+        }
     },
     {
-      "name": "terminal missing parameter value parameterised dict",
-      "raw": ["a=3;c=5;d"],
-      "header_type": "dictionary",
-      "expected": {
-          "a": [3, {"c": 5, "d": true}]
-      }
+        "name": "terminal missing parameter value parameterised dict",
+        "raw": ["a=3;c=5;d"],
+        "header_type": "dictionary",
+        "expected": {
+            "a": [3, {"c": 5, "d": true}]
+        }
     },
     {
-      "name": "no whitespace parameterised dict",
-      "raw": ["a=b;c=1,d=e;f=2"],
-      "header_type": "dictionary",
-      "expected": {
-          "a": [{"__type": "token", "value": "b"}, {"c": 1}],
-          "d": [{"__type": "token", "value": "e"}, {"f": 2}]
-      },
-      "canonical": ["a=b;c=1, d=e;f=2"]
+        "name": "no whitespace parameterised dict",
+        "raw": ["a=b;c=1,d=e;f=2"],
+        "header_type": "dictionary",
+        "expected": {
+            "a": [{"__type": "token", "value": "b"}, {"c": 1}],
+            "d": [{"__type": "token", "value": "e"}, {"f": 2}]
+        },
+        "canonical": ["a=b;c=1, d=e;f=2"]
     },
     {
-      "name": "whitespace before = parameterised dict",
-      "raw": ["a=b;q =0.5"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "whitespace before = parameterised dict",
+        "raw": ["a=b;q =0.5"],
+        "header_type": "dictionary",
+        "must_fail": true
     },
     {
-      "name": "whitespace after = parameterised dict",
-      "raw": ["a=b;q= 0.5"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "whitespace after = parameterised dict",
+        "raw": ["a=b;q= 0.5"],
+        "header_type": "dictionary",
+        "must_fail": true
     },
     {
-      "name": "whitespace before ; parameterised dict",
-      "raw": ["a=b ;q=0.5"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "whitespace before ; parameterised dict",
+        "raw": ["a=b ;q=0.5"],
+        "header_type": "dictionary",
+        "must_fail": true
     },
     {
-      "name": "whitespace after ; parameterised dict",
-      "raw": ["a=b; q=0.5"],
-      "header_type": "dictionary",
-      "expected": {
-          "a": [{"__type": "token", "value": "b"}, {"q": 0.5}]
-      },
-      "canonical": ["a=b;q=0.5"]
+        "name": "whitespace after ; parameterised dict",
+        "raw": ["a=b; q=0.5"],
+        "header_type": "dictionary",
+        "expected": {
+            "a": [{"__type": "token", "value": "b"}, {"q": 0.5}]
+        },
+        "canonical": ["a=b;q=0.5"]
     },
     {
-      "name": "extra whitespace parameterised dict",
-      "raw": ["a=b;  c=1  ,  d=e; f=2; g=3"],
-      "header_type": "dictionary",
-      "expected": {
-          "a": [{"__type": "token", "value": "b"}, {"c": 1}],
-          "d": [{"__type": "token", "value": "e"}, {"f": 2, "g": 3}]
-      },
-      "canonical": ["a=b;c=1, d=e;f=2;g=3"]
+        "name": "extra whitespace parameterised dict",
+        "raw": ["a=b;  c=1  ,  d=e; f=2; g=3"],
+        "header_type": "dictionary",
+        "expected": {
+            "a": [{"__type": "token", "value": "b"}, {"c": 1}],
+            "d": [{"__type": "token", "value": "e"}, {"f": 2, "g": 3}]
+        },
+        "canonical": ["a=b;c=1, d=e;f=2;g=3"]
     },
     {
-      "name": "two lines parameterised list",
-      "raw": ["a=b;c=1", "d=e;f=2"],
-      "header_type": "dictionary",
-      "expected": {
-          "a": [{"__type": "token", "value": "b"}, {"c": 1}],
-          "d": [{"__type": "token", "value": "e"}, {"f": 2}]
-      },
-      "canonical": ["a=b;c=1, d=e;f=2"]
+        "name": "two lines parameterised list",
+        "raw": ["a=b;c=1", "d=e;f=2"],
+        "header_type": "dictionary",
+        "expected": {
+            "a": [{"__type": "token", "value": "b"}, {"c": 1}],
+            "d": [{"__type": "token", "value": "e"}, {"f": 2}]
+        },
+        "canonical": ["a=b;c=1, d=e;f=2"]
     },
     {
-      "name": "trailing comma parameterised list",
-      "raw": ["a=b; q=1.0,"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "trailing comma parameterised list",
+        "raw": ["a=b; q=1.0,"],
+        "header_type": "dictionary",
+        "must_fail": true
     },
     {
-      "name": "empty item parameterised list",
-      "raw": ["a=b; q=1.0,,c=d"],
-      "header_type": "dictionary",
-      "must_fail": true
+        "name": "empty item parameterised list",
+        "raw": ["a=b; q=1.0,,c=d"],
+        "header_type": "dictionary",
+        "must_fail": true
     }
 ]

--- a/param-list.json
+++ b/param-list.json
@@ -1,28 +1,28 @@
 [
     {
-      "name": "basic parameterised list",
-      "raw": ["abc_123;a=1;b=2; cdef_456, ghi;q=9;r=\"+w\""],
-      "header_type": "list",
-      "expected": [
-        [{"__type": "token", "value": "abc_123"}, {"a": 1, "b": 2, "cdef_456": true}],
-        [{"__type": "token", "value": "ghi"}, {"q": 9, "r": "+w"}]
-      ],
-      "canonical": ["abc_123;a=1;b=2;cdef_456, ghi;q=9;r=\"+w\""]
+        "name": "basic parameterised list",
+        "raw": ["abc_123;a=1;b=2; cdef_456, ghi;q=9;r=\"+w\""],
+        "header_type": "list",
+        "expected": [
+            [{"__type": "token", "value": "abc_123"}, {"a": 1, "b": 2, "cdef_456": true}],
+            [{"__type": "token", "value": "ghi"}, {"q": 9, "r": "+w"}]
+        ],
+        "canonical": ["abc_123;a=1;b=2;cdef_456, ghi;q=9;r=\"+w\""]
     },
     {
-      "name": "single item parameterised list",
-      "raw": ["text/html;q=1.0"],
-      "header_type": "list",
-      "expected": [
-        [{"__type": "token", "value": "text/html"}, {"q": 1.0}]
-      ]
+        "name": "single item parameterised list",
+        "raw": ["text/html;q=1.0"],
+        "header_type": "list",
+        "expected": [
+            [{"__type": "token", "value": "text/html"}, {"q": 1.0}]
+        ]
     },
     {
         "name": "missing parameter value parameterised list",
         "raw": ["text/html;a;q=1.0"],
         "header_type": "list",
         "expected": [
-          [{"__type": "token", "value": "text/html"}, {"a": true, "q": 1.0}]
+            [{"__type": "token", "value": "text/html"}, {"a": true, "q": 1.0}]
         ]
     },
     {
@@ -30,79 +30,79 @@
         "raw": ["text/html;q=1.0;a"],
         "header_type": "list",
         "expected": [
-          [{"__type": "token", "value": "text/html"}, {"q": 1.0, "a": true}]
+            [{"__type": "token", "value": "text/html"}, {"q": 1.0, "a": true}]
         ]
     },
     {
-      "name": "no whitespace parameterised list",
-      "raw": ["text/html,text/plain;q=0.5"],
-      "header_type": "list",
-      "expected": [
-        [{"__type": "token", "value": "text/html"}, {}],
-        [{"__type": "token", "value": "text/plain"}, {"q": 0.5}]
-      ],
-      "canonical": ["text/html, text/plain;q=0.5"]
+        "name": "no whitespace parameterised list",
+        "raw": ["text/html,text/plain;q=0.5"],
+        "header_type": "list",
+        "expected": [
+            [{"__type": "token", "value": "text/html"}, {}],
+            [{"__type": "token", "value": "text/plain"}, {"q": 0.5}]
+        ],
+        "canonical": ["text/html, text/plain;q=0.5"]
     },
     {
-      "name": "whitespace before = parameterised list",
-      "raw": ["text/html, text/plain;q =0.5"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "whitespace before = parameterised list",
+        "raw": ["text/html, text/plain;q =0.5"],
+        "header_type": "list",
+        "must_fail": true
     },
     {
-      "name": "whitespace after = parameterised list",
-      "raw": ["text/html, text/plain;q= 0.5"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "whitespace after = parameterised list",
+        "raw": ["text/html, text/plain;q= 0.5"],
+        "header_type": "list",
+        "must_fail": true
     },
     {
-      "name": "whitespace before ; parameterised list",
-      "raw": ["text/html, text/plain ;q=0.5"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "whitespace before ; parameterised list",
+        "raw": ["text/html, text/plain ;q=0.5"],
+        "header_type": "list",
+        "must_fail": true
     },
     {
-      "name": "whitespace after ; parameterised list",
-      "raw": ["text/html, text/plain; q=0.5"],
-      "header_type": "list",
-      "expected": [
-          [{"__type": "token", "value": "text/html"}, {}],
-          [{"__type": "token", "value": "text/plain"}, {"q": 0.5}]
-      ],
-      "canonical": ["text/html, text/plain;q=0.5"]
+        "name": "whitespace after ; parameterised list",
+        "raw": ["text/html, text/plain; q=0.5"],
+        "header_type": "list",
+        "expected": [
+            [{"__type": "token", "value": "text/html"}, {}],
+            [{"__type": "token", "value": "text/plain"}, {"q": 0.5}]
+        ],
+        "canonical": ["text/html, text/plain;q=0.5"]
     },
     {
-      "name": "extra whitespace parameterised list",
-      "raw": ["text/html  ,  text/plain;  q=0.5;  charset=utf-8"],
-      "header_type": "list",
-      "expected": [
-        [{"__type": "token", "value": "text/html"}, {}],
-        [{"__type": "token", "value": "text/plain"},
-           {"q": 0.5, "charset": {"__type": "token", "value": "utf-8"}
-        }]
-      ],
-      "canonical": ["text/html, text/plain;q=0.5;charset=utf-8"]
+        "name": "extra whitespace parameterised list",
+        "raw": ["text/html  ,  text/plain;  q=0.5;  charset=utf-8"],
+        "header_type": "list",
+        "expected": [
+            [{"__type": "token", "value": "text/html"}, {}],
+            [{"__type": "token", "value": "text/plain"},
+               {"q": 0.5, "charset": {"__type": "token", "value": "utf-8"}
+            }]
+        ],
+        "canonical": ["text/html, text/plain;q=0.5;charset=utf-8"]
     },
     {
-      "name": "two lines parameterised list",
-      "raw": ["text/html", "text/plain;q=0.5"],
-      "header_type": "list",
-      "expected": [
-        [{"__type": "token", "value": "text/html"}, {}],
-        [{"__type": "token", "value": "text/plain"}, {"q": 0.5}]
-      ],
-      "canonical": ["text/html, text/plain;q=0.5"]
+        "name": "two lines parameterised list",
+        "raw": ["text/html", "text/plain;q=0.5"],
+        "header_type": "list",
+        "expected": [
+            [{"__type": "token", "value": "text/html"}, {}],
+            [{"__type": "token", "value": "text/plain"}, {"q": 0.5}]
+        ],
+        "canonical": ["text/html, text/plain;q=0.5"]
     },
     {
-      "name": "trailing comma parameterised list",
-      "raw": ["text/html,text/plain;q=0.5,"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "trailing comma parameterised list",
+        "raw": ["text/html,text/plain;q=0.5,"],
+        "header_type": "list",
+        "must_fail": true
     },
     {
-      "name": "empty item parameterised list",
-      "raw": ["text/html,,text/plain;q=0.5,"],
-      "header_type": "list",
-      "must_fail": true
+        "name": "empty item parameterised list",
+        "raw": ["text/html,,text/plain;q=0.5,"],
+        "header_type": "list",
+        "must_fail": true
     }
 ]

--- a/param-listlist.json
+++ b/param-listlist.json
@@ -1,36 +1,36 @@
 [
     {
-      "name": "parameterised inner list",
-      "raw": ["(abc_123);a=1;b=2, cdef_456"],
-      "header_type": "list",
-      "expected": [
-          [
-              [[{"__type": "token", "value": "abc_123"}, {}]],
-              {"a": 1, "b": 2}
-          ],
-          [{"__type": "token", "value": "cdef_456"}, {}]
-      ]
+        "name": "parameterised inner list",
+        "raw": ["(abc_123);a=1;b=2, cdef_456"],
+        "header_type": "list",
+        "expected": [
+            [
+                [[{"__type": "token", "value": "abc_123"}, {}]],
+                {"a": 1, "b": 2}
+            ],
+            [{"__type": "token", "value": "cdef_456"}, {}]
+        ]
     },
     {
-      "name": "parameterised inner list item",
-      "raw": ["(abc_123;a=1;b=2;cdef_456)"],
-      "header_type": "list",
-      "expected": [
-          [
-              [[{"__type": "token", "value": "abc_123"}, {"a": 1, "b": 2, "cdef_456": true}]],
-              {}
-          ]
-      ]
+        "name": "parameterised inner list item",
+        "raw": ["(abc_123;a=1;b=2;cdef_456)"],
+        "header_type": "list",
+        "expected": [
+            [
+                [[{"__type": "token", "value": "abc_123"}, {"a": 1, "b": 2, "cdef_456": true}]],
+                {}
+            ]
+        ]
     },
     {
-      "name": "parameterised inner list with parameterised item",
-      "raw": ["(abc_123;a=1;b=2);cdef_456"],
-      "header_type": "list",
-      "expected": [
-          [
-              [[{"__type": "token", "value": "abc_123"}, {"a": 1, "b": 2}]],
-              {"cdef_456": true}
-          ]
-      ]
+        "name": "parameterised inner list with parameterised item",
+        "raw": ["(abc_123;a=1;b=2);cdef_456"],
+        "header_type": "list",
+        "expected": [
+            [
+                [[{"__type": "token", "value": "abc_123"}, {"a": 1, "b": 2}]],
+                {"cdef_456": true}
+            ]
+        ]
     }
 ]

--- a/serialisation-tests/number.json
+++ b/serialisation-tests/number.json
@@ -1,60 +1,57 @@
 [
-  {
-    "name": "too big postive integer - serialize",
-    "header_type": "item",
-    "expected": [1000000000000000, {}],
-    "must_fail": true
-  },
-  {
-    "name": "too big negative integer - serialize",
-    "header_type": "item",
-    "expected": [-1000000000000000, {}],
-    "must_fail": true
-  },
-  {
-    "name": "too big postive decimal - serialize",
-    "header_type": "item",
-    "expected": [1000000000000.0, {}],
-    "must_fail": true
-  },
-  {
-    "name": "too big negative decimal - serialize",
-    "header_type": "item",
-    "expected": [-1000000000000.0, {}],
-    "must_fail": true
-  },
-
- {
-    "name": "round positive odd decimal - serialize",
-    "header_type": "item",
-    "expected": [0.0015, {}],
-    "canonical": ["0.002"]
-  },
-  {
-    "name": "round positive even decimal - serialize",
-    "header_type": "item",
-    "expected": [0.0025, {}],
-    "canonical": ["0.002"]
-  },
-
-  {
-    "name": "round negative odd decimal - serialize",
-    "header_type": "item",
-    "expected": [-0.0015, {}],
-    "canonical": ["-0.002"]
-  },
-  {
-    "name": "round negative even decimal - serialize",
-    "header_type": "item",
-    "expected": [-0.0025, {}],
-    "canonical": ["-0.002"]
-  },
-
-  {
-    "name": "decimal round up to integer part - serialize",
-    "header_type": "item",
-    "expected": [9.9995, {}],
-    "canonical": ["10.0"]
-  }
+    {
+        "name": "too big postive integer - serialize",
+        "header_type": "item",
+        "expected": [1000000000000000, {}],
+        "must_fail": true
+    },
+    {
+        "name": "too big negative integer - serialize",
+        "header_type": "item",
+        "expected": [-1000000000000000, {}],
+        "must_fail": true
+    },
+    {
+        "name": "too big postive decimal - serialize",
+        "header_type": "item",
+        "expected": [1000000000000.0, {}],
+        "must_fail": true
+    },
+    {
+        "name": "too big negative decimal - serialize",
+        "header_type": "item",
+        "expected": [-1000000000000.0, {}],
+        "must_fail": true
+    },
+    {
+        "name": "round positive odd decimal - serialize",
+        "header_type": "item",
+        "expected": [0.0015, {}],
+        "canonical": ["0.002"]
+    },
+    {
+        "name": "round positive even decimal - serialize",
+        "header_type": "item",
+        "expected": [0.0025, {}],
+        "canonical": ["0.002"]
+    },
+    {
+        "name": "round negative odd decimal - serialize",
+        "header_type": "item",
+        "expected": [-0.0015, {}],
+        "canonical": ["-0.002"]
+    },
+    {
+        "name": "round negative even decimal - serialize",
+        "header_type": "item",
+        "expected": [-0.0025, {}],
+        "canonical": ["-0.002"]
+    },
+    {
+        "name": "decimal round up to integer part - serialize",
+        "header_type": "item",
+        "expected": [9.9995, {}],
+        "canonical": ["10.0"]
+    }
 ]
 

--- a/string.json
+++ b/string.json
@@ -1,80 +1,80 @@
 [
     {
-      "name": "basic string",
-      "raw": ["\"foo bar\""],
-      "header_type": "item",
-      "expected": ["foo bar", {}]
+        "name": "basic string",
+        "raw": ["\"foo bar\""],
+        "header_type": "item",
+        "expected": ["foo bar", {}]
     },
     {
-      "name": "empty string",
-      "raw": ["\"\""],
-      "header_type": "item",
-      "expected": ["", {}]
+        "name": "empty string",
+        "raw": ["\"\""],
+        "header_type": "item",
+        "expected": ["", {}]
     },
     {
-      "name": "long string",
-      "raw": ["\"foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo \""],
-      "header_type": "item",
-      "expected": ["foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo ", {}]
+        "name": "long string",
+        "raw": ["\"foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo \""],
+        "header_type": "item",
+        "expected": ["foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo ", {}]
     },
     {
-      "name": "whitespace string",
-      "raw": ["\"   \""],
-      "header_type": "item",
-      "expected": ["   ", {}]
+        "name": "whitespace string",
+        "raw": ["\"   \""],
+        "header_type": "item",
+        "expected": ["   ", {}]
     },
     {
-      "name": "non-ascii string",
-      "raw": ["\"füü\""],
-      "header_type": "item",
-      "must_fail": true
+        "name": "non-ascii string",
+        "raw": ["\"füü\""],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "tab in string",
-      "raw": ["\"\\t\""],
-      "header_type": "item",
-      "must_fail": true
+        "name": "tab in string",
+        "raw": ["\"\\t\""],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "newline in string",
-      "raw": ["\" \\n \""],
-      "header_type": "item",
-      "must_fail": true
+        "name": "newline in string",
+        "raw": ["\" \\n \""],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "single quoted string",
-      "raw": ["'foo'"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "single quoted string",
+        "raw": ["'foo'"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "unbalanced string",
-      "raw": ["\"foo"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "unbalanced string",
+        "raw": ["\"foo"],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "string quoting",
-      "raw": ["\"foo \\\"bar\\\" \\\\ baz\""],
-      "header_type": "item",
-      "expected": ["foo \"bar\" \\ baz", {}]
+        "name": "string quoting",
+        "raw": ["\"foo \\\"bar\\\" \\\\ baz\""],
+        "header_type": "item",
+        "expected": ["foo \"bar\" \\ baz", {}]
     },
     {
-      "name": "bad string quoting",
-      "raw": ["\"foo \\,\""],
-      "header_type": "item",
-      "must_fail": true
+        "name": "bad string quoting",
+        "raw": ["\"foo \\,\""],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "ending string quote",
-      "raw": ["\"foo \\\""],
-      "header_type": "item",
-      "must_fail": true
+        "name": "ending string quote",
+        "raw": ["\"foo \\\""],
+        "header_type": "item",
+        "must_fail": true
     },
     {
-      "name": "abruptly ending string quote",
-      "raw": ["\"foo \\"],
-      "header_type": "item",
-      "must_fail": true
+        "name": "abruptly ending string quote",
+        "raw": ["\"foo \\"],
+        "header_type": "item",
+        "must_fail": true
     }
 ]

--- a/token.json
+++ b/token.json
@@ -1,38 +1,38 @@
 [
     {
-      "name": "basic token - item",
-      "raw": ["a_b-c.d3:f%00/*"],
-      "header_type": "item",
-      "expected": [{"__type": "token", "value": "a_b-c.d3:f%00/*"}, {}]
+        "name": "basic token - item",
+        "raw": ["a_b-c.d3:f%00/*"],
+        "header_type": "item",
+        "expected": [{"__type": "token", "value": "a_b-c.d3:f%00/*"}, {}]
     },
     {
-      "name": "token with capitals - item",
-      "raw": ["fooBar"],
-      "header_type": "item",
-      "expected": [{"__type": "token", "value": "fooBar"}, {}]
+        "name": "token with capitals - item",
+        "raw": ["fooBar"],
+        "header_type": "item",
+        "expected": [{"__type": "token", "value": "fooBar"}, {}]
     },
     {
-      "name": "token starting with capitals - item",
-      "raw": ["FooBar"],
-      "header_type": "item",
-      "expected": [{"__type": "token", "value": "FooBar"}, {}]
+        "name": "token starting with capitals - item",
+        "raw": ["FooBar"],
+        "header_type": "item",
+        "expected": [{"__type": "token", "value": "FooBar"}, {}]
     },
     {
-      "name": "basic token - list",
-      "raw": ["a_b-c3/*"],
-      "header_type": "list",
-      "expected": [[{"__type": "token", "value": "a_b-c3/*"}, {}]]
+        "name": "basic token - list",
+        "raw": ["a_b-c3/*"],
+        "header_type": "list",
+        "expected": [[{"__type": "token", "value": "a_b-c3/*"}, {}]]
     },
     {
-      "name": "token with capitals - list",
-      "raw": ["fooBar"],
-      "header_type": "list",
-      "expected": [[{"__type": "token", "value": "fooBar"}, {}]]
+        "name": "token with capitals - list",
+        "raw": ["fooBar"],
+        "header_type": "list",
+        "expected": [[{"__type": "token", "value": "fooBar"}, {}]]
     },
     {
-      "name": "token starting with capitals - list",
-      "raw": ["FooBar"],
-      "header_type": "list",
-      "expected": [[{"__type": "token", "value": "FooBar"}, {}]]
+        "name": "token starting with capitals - list",
+        "raw": ["FooBar"],
+        "header_type": "list",
+        "expected": [[{"__type": "token", "value": "FooBar"}, {}]]
     }
 ]


### PR DESCRIPTION
Indentation is inconsistent: generated files use 4 spaces, some files use 2 spaces, many are inconsistent within a single file.

This normalizes all files to 4 space indentation, and adds an `.editorconfig` for IDEs that understand it.