### PR TITLE
Avoid a trailing zero in the large decimal test.

### DIFF
--- a/serialisation-tests/number.json
+++ b/serialisation-tests/number.json
@@ -14,13 +14,13 @@
     {
         "name": "too big postive decimal - serialize",
         "header_type": "item",
-        "expected": [1000000000000.0, {}],
+        "expected": [1000000000000.1, {}],
         "must_fail": true
     },
     {
         "name": "too big negative decimal - serialize",
         "header_type": "item",
-        "expected": [-1000000000000.0, {}],
+        "expected": [-1000000000000.1, {}],
         "must_fail": true
     },
     {


### PR DESCRIPTION
In some JSON parsers we can have trouble telling the difference between
JSON integers and floats, and so we end up needing to test for them at
runtime. All integers can be parsed as floats, so the best order for
testing is to test for integer first, then float. The risk is that some
JSON parsers will quietly assume you wanted that float converted to an
Int if it's possible to do so.

This patch changes the two large decimal tests to use a non-zero decimal
digit so they are unambiguously not integers, avoiding ambiguity on the
intended type in this test.