### PR TITLE
Distinct string-generated test names

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -69,7 +69,7 @@ for c in ALL_CHARS:
 ## escaped characters
 for c in ALL_CHARS:
     test = {
-        "name": "0x%02x in string" % c,
+        "name": "Escaped 0x%02x in string" % c,
         "raw": ['"\\%s"' % chr(c)],
         "header_type": "item",
     }

--- a/number.json
+++ b/number.json
@@ -12,13 +12,6 @@
         "expected": [0, []]
     },
     {
-        "name": "leading 0 zero",
-        "raw": ["00"],
-        "header_type": "item",
-        "expected": [0, []],
-        "canonical": ["0"]
-    },
-    {
         "name": "negative zero",
         "raw": ["-0"],
         "header_type": "item",

--- a/string-generated.json
+++ b/string-generated.json
@@ -1303,7 +1303,7 @@
         "must_fail": true
     },
     {
-        "name": "0x00 in string",
+        "name": "Escaped 0x00 in string",
         "raw": [
             "\"\\\u0000\""
         ],
@@ -1311,7 +1311,7 @@
         "must_fail": true
     },
     {
-        "name": "0x01 in string",
+        "name": "Escaped 0x01 in string",
         "raw": [
             "\"\\\u0001\""
         ],
@@ -1319,7 +1319,7 @@
         "must_fail": true
     },
     {
-        "name": "0x02 in string",
+        "name": "Escaped 0x02 in string",
         "raw": [
             "\"\\\u0002\""
         ],
@@ -1327,7 +1327,7 @@
         "must_fail": true
     },
     {
-        "name": "0x03 in string",
+        "name": "Escaped 0x03 in string",
         "raw": [
             "\"\\\u0003\""
         ],
@@ -1335,7 +1335,7 @@
         "must_fail": true
     },
     {
-        "name": "0x04 in string",
+        "name": "Escaped 0x04 in string",
         "raw": [
             "\"\\\u0004\""
         ],
@@ -1343,7 +1343,7 @@
         "must_fail": true
     },
     {
-        "name": "0x05 in string",
+        "name": "Escaped 0x05 in string",
         "raw": [
             "\"\\\u0005\""
         ],
@@ -1351,7 +1351,7 @@
         "must_fail": true
     },
     {
-        "name": "0x06 in string",
+        "name": "Escaped 0x06 in string",
         "raw": [
             "\"\\\u0006\""
         ],
@@ -1359,7 +1359,7 @@
         "must_fail": true
     },
     {
-        "name": "0x07 in string",
+        "name": "Escaped 0x07 in string",
         "raw": [
             "\"\\\u0007\""
         ],
@@ -1367,7 +1367,7 @@
         "must_fail": true
     },
     {
-        "name": "0x08 in string",
+        "name": "Escaped 0x08 in string",
         "raw": [
             "\"\\\b\""
         ],
@@ -1375,7 +1375,7 @@
         "must_fail": true
     },
     {
-        "name": "0x09 in string",
+        "name": "Escaped 0x09 in string",
         "raw": [
             "\"\\\t\""
         ],
@@ -1383,7 +1383,7 @@
         "must_fail": true
     },
     {
-        "name": "0x0a in string",
+        "name": "Escaped 0x0a in string",
         "raw": [
             "\"\\\n\""
         ],
@@ -1391,7 +1391,7 @@
         "must_fail": true
     },
     {
-        "name": "0x0b in string",
+        "name": "Escaped 0x0b in string",
         "raw": [
             "\"\\\u000b\""
         ],
@@ -1399,7 +1399,7 @@
         "must_fail": true
     },
     {
-        "name": "0x0c in string",
+        "name": "Escaped 0x0c in string",
         "raw": [
             "\"\\\f\""
         ],
@@ -1407,7 +1407,7 @@
         "must_fail": true
     },
     {
-        "name": "0x0d in string",
+        "name": "Escaped 0x0d in string",
         "raw": [
             "\"\\\r\""
         ],
@@ -1415,7 +1415,7 @@
         "must_fail": true
     },
     {
-        "name": "0x0e in string",
+        "name": "Escaped 0x0e in string",
         "raw": [
             "\"\\\u000e\""
         ],
@@ -1423,7 +1423,7 @@
         "must_fail": true
     },
     {
-        "name": "0x0f in string",
+        "name": "Escaped 0x0f in string",
         "raw": [
             "\"\\\u000f\""
         ],
@@ -1431,7 +1431,7 @@
         "must_fail": true
     },
     {
-        "name": "0x10 in string",
+        "name": "Escaped 0x10 in string",
         "raw": [
             "\"\\\u0010\""
         ],
@@ -1439,7 +1439,7 @@
         "must_fail": true
     },
     {
-        "name": "0x11 in string",
+        "name": "Escaped 0x11 in string",
         "raw": [
             "\"\\\u0011\""
         ],
@@ -1447,7 +1447,7 @@
         "must_fail": true
     },
     {
-        "name": "0x12 in string",
+        "name": "Escaped 0x12 in string",
         "raw": [
             "\"\\\u0012\""
         ],
@@ -1455,7 +1455,7 @@
         "must_fail": true
     },
     {
-        "name": "0x13 in string",
+        "name": "Escaped 0x13 in string",
         "raw": [
             "\"\\\u0013\""
         ],
@@ -1463,7 +1463,7 @@
         "must_fail": true
     },
     {
-        "name": "0x14 in string",
+        "name": "Escaped 0x14 in string",
         "raw": [
             "\"\\\u0014\""
         ],
@@ -1471,7 +1471,7 @@
         "must_fail": true
     },
     {
-        "name": "0x15 in string",
+        "name": "Escaped 0x15 in string",
         "raw": [
             "\"\\\u0015\""
         ],
@@ -1479,7 +1479,7 @@
         "must_fail": true
     },
     {
-        "name": "0x16 in string",
+        "name": "Escaped 0x16 in string",
         "raw": [
             "\"\\\u0016\""
         ],
@@ -1487,7 +1487,7 @@
         "must_fail": true
     },
     {
-        "name": "0x17 in string",
+        "name": "Escaped 0x17 in string",
         "raw": [
             "\"\\\u0017\""
         ],
@@ -1495,7 +1495,7 @@
         "must_fail": true
     },
     {
-        "name": "0x18 in string",
+        "name": "Escaped 0x18 in string",
         "raw": [
             "\"\\\u0018\""
         ],
@@ -1503,7 +1503,7 @@
         "must_fail": true
     },
     {
-        "name": "0x19 in string",
+        "name": "Escaped 0x19 in string",
         "raw": [
             "\"\\\u0019\""
         ],
@@ -1511,7 +1511,7 @@
         "must_fail": true
     },
     {
-        "name": "0x1a in string",
+        "name": "Escaped 0x1a in string",
         "raw": [
             "\"\\\u001a\""
         ],
@@ -1519,7 +1519,7 @@
         "must_fail": true
     },
     {
-        "name": "0x1b in string",
+        "name": "Escaped 0x1b in string",
         "raw": [
             "\"\\\u001b\""
         ],
@@ -1527,7 +1527,7 @@
         "must_fail": true
     },
     {
-        "name": "0x1c in string",
+        "name": "Escaped 0x1c in string",
         "raw": [
             "\"\\\u001c\""
         ],
@@ -1535,7 +1535,7 @@
         "must_fail": true
     },
     {
-        "name": "0x1d in string",
+        "name": "Escaped 0x1d in string",
         "raw": [
             "\"\\\u001d\""
         ],
@@ -1543,7 +1543,7 @@
         "must_fail": true
     },
     {
-        "name": "0x1e in string",
+        "name": "Escaped 0x1e in string",
         "raw": [
             "\"\\\u001e\""
         ],
@@ -1551,7 +1551,7 @@
         "must_fail": true
     },
     {
-        "name": "0x1f in string",
+        "name": "Escaped 0x1f in string",
         "raw": [
             "\"\\\u001f\""
         ],
@@ -1559,7 +1559,7 @@
         "must_fail": true
     },
     {
-        "name": "0x20 in string",
+        "name": "Escaped 0x20 in string",
         "raw": [
             "\"\\ \""
         ],
@@ -1567,7 +1567,7 @@
         "must_fail": true
     },
     {
-        "name": "0x21 in string",
+        "name": "Escaped 0x21 in string",
         "raw": [
             "\"\\!\""
         ],
@@ -1575,7 +1575,7 @@
         "must_fail": true
     },
     {
-        "name": "0x22 in string",
+        "name": "Escaped 0x22 in string",
         "raw": [
             "\"\\\"\""
         ],
@@ -1586,7 +1586,7 @@
         ]
     },
     {
-        "name": "0x23 in string",
+        "name": "Escaped 0x23 in string",
         "raw": [
             "\"\\#\""
         ],
@@ -1594,7 +1594,7 @@
         "must_fail": true
     },
     {
-        "name": "0x24 in string",
+        "name": "Escaped 0x24 in string",
         "raw": [
             "\"\\$\""
         ],
@@ -1602,7 +1602,7 @@
         "must_fail": true
     },
     {
-        "name": "0x25 in string",
+        "name": "Escaped 0x25 in string",
         "raw": [
             "\"\\%\""
         ],
@@ -1610,7 +1610,7 @@
         "must_fail": true
     },
     {
-        "name": "0x26 in string",
+        "name": "Escaped 0x26 in string",
         "raw": [
             "\"\\&\""
         ],
@@ -1618,7 +1618,7 @@
         "must_fail": true
     },
     {
-        "name": "0x27 in string",
+        "name": "Escaped 0x27 in string",
         "raw": [
             "\"\\'\""
         ],
@@ -1626,7 +1626,7 @@
         "must_fail": true
     },
     {
-        "name": "0x28 in string",
+        "name": "Escaped 0x28 in string",
         "raw": [
             "\"\\(\""
         ],
@@ -1634,7 +1634,7 @@
         "must_fail": true
     },
     {
-        "name": "0x29 in string",
+        "name": "Escaped 0x29 in string",
         "raw": [
             "\"\\)\""
         ],
@@ -1642,7 +1642,7 @@
         "must_fail": true
     },
     {
-        "name": "0x2a in string",
+        "name": "Escaped 0x2a in string",
         "raw": [
             "\"\\*\""
         ],
@@ -1650,7 +1650,7 @@
         "must_fail": true
     },
     {
-        "name": "0x2b in string",
+        "name": "Escaped 0x2b in string",
         "raw": [
             "\"\\+\""
         ],
@@ -1658,7 +1658,7 @@
         "must_fail": true
     },
     {
-        "name": "0x2c in string",
+        "name": "Escaped 0x2c in string",
         "raw": [
             "\"\\,\""
         ],
@@ -1666,7 +1666,7 @@
         "must_fail": true
     },
     {
-        "name": "0x2d in string",
+        "name": "Escaped 0x2d in string",
         "raw": [
             "\"\\-\""
         ],
@@ -1674,7 +1674,7 @@
         "must_fail": true
     },
     {
-        "name": "0x2e in string",
+        "name": "Escaped 0x2e in string",
         "raw": [
             "\"\\.\""
         ],
@@ -1682,7 +1682,7 @@
         "must_fail": true
     },
     {
-        "name": "0x2f in string",
+        "name": "Escaped 0x2f in string",
         "raw": [
             "\"\\/\""
         ],
@@ -1690,7 +1690,7 @@
         "must_fail": true
     },
     {
-        "name": "0x30 in string",
+        "name": "Escaped 0x30 in string",
         "raw": [
             "\"\\0\""
         ],
@@ -1698,7 +1698,7 @@
         "must_fail": true
     },
     {
-        "name": "0x31 in string",
+        "name": "Escaped 0x31 in string",
         "raw": [
             "\"\\1\""
         ],
@@ -1706,7 +1706,7 @@
         "must_fail": true
     },
     {
-        "name": "0x32 in string",
+        "name": "Escaped 0x32 in string",
         "raw": [
             "\"\\2\""
         ],
@@ -1714,7 +1714,7 @@
         "must_fail": true
     },
     {
-        "name": "0x33 in string",
+        "name": "Escaped 0x33 in string",
         "raw": [
             "\"\\3\""
         ],
@@ -1722,7 +1722,7 @@
         "must_fail": true
     },
     {
-        "name": "0x34 in string",
+        "name": "Escaped 0x34 in string",
         "raw": [
             "\"\\4\""
         ],
@@ -1730,7 +1730,7 @@
         "must_fail": true
     },
     {
-        "name": "0x35 in string",
+        "name": "Escaped 0x35 in string",
         "raw": [
             "\"\\5\""
         ],
@@ -1738,7 +1738,7 @@
         "must_fail": true
     },
     {
-        "name": "0x36 in string",
+        "name": "Escaped 0x36 in string",
         "raw": [
             "\"\\6\""
         ],
@@ -1746,7 +1746,7 @@
         "must_fail": true
     },
     {
-        "name": "0x37 in string",
+        "name": "Escaped 0x37 in string",
         "raw": [
             "\"\\7\""
         ],
@@ -1754,7 +1754,7 @@
         "must_fail": true
     },
     {
-        "name": "0x38 in string",
+        "name": "Escaped 0x38 in string",
         "raw": [
             "\"\\8\""
         ],
@@ -1762,7 +1762,7 @@
         "must_fail": true
     },
     {
-        "name": "0x39 in string",
+        "name": "Escaped 0x39 in string",
         "raw": [
             "\"\\9\""
         ],
@@ -1770,7 +1770,7 @@
         "must_fail": true
     },
     {
-        "name": "0x3a in string",
+        "name": "Escaped 0x3a in string",
         "raw": [
             "\"\\:\""
         ],
@@ -1778,7 +1778,7 @@
         "must_fail": true
     },
     {
-        "name": "0x3b in string",
+        "name": "Escaped 0x3b in string",
         "raw": [
             "\"\\;\""
         ],
@@ -1786,7 +1786,7 @@
         "must_fail": true
     },
     {
-        "name": "0x3c in string",
+        "name": "Escaped 0x3c in string",
         "raw": [
             "\"\\<\""
         ],
@@ -1794,7 +1794,7 @@
         "must_fail": true
     },
     {
-        "name": "0x3d in string",
+        "name": "Escaped 0x3d in string",
         "raw": [
             "\"\\=\""
         ],
@@ -1802,7 +1802,7 @@
         "must_fail": true
     },
     {
-        "name": "0x3e in string",
+        "name": "Escaped 0x3e in string",
         "raw": [
             "\"\\>\""
         ],
@@ -1810,7 +1810,7 @@
         "must_fail": true
     },
     {
-        "name": "0x3f in string",
+        "name": "Escaped 0x3f in string",
         "raw": [
             "\"\\?\""
         ],
@@ -1818,7 +1818,7 @@
         "must_fail": true
     },
     {
-        "name": "0x40 in string",
+        "name": "Escaped 0x40 in string",
         "raw": [
             "\"\\@\""
         ],
@@ -1826,7 +1826,7 @@
         "must_fail": true
     },
     {
-        "name": "0x41 in string",
+        "name": "Escaped 0x41 in string",
         "raw": [
             "\"\\A\""
         ],
@@ -1834,7 +1834,7 @@
         "must_fail": true
     },
     {
-        "name": "0x42 in string",
+        "name": "Escaped 0x42 in string",
         "raw": [
             "\"\\B\""
         ],
@@ -1842,7 +1842,7 @@
         "must_fail": true
     },
     {
-        "name": "0x43 in string",
+        "name": "Escaped 0x43 in string",
         "raw": [
             "\"\\C\""
         ],
@@ -1850,7 +1850,7 @@
         "must_fail": true
     },
     {
-        "name": "0x44 in string",
+        "name": "Escaped 0x44 in string",
         "raw": [
             "\"\\D\""
         ],
@@ -1858,7 +1858,7 @@
         "must_fail": true
     },
     {
-        "name": "0x45 in string",
+        "name": "Escaped 0x45 in string",
         "raw": [
             "\"\\E\""
         ],
@@ -1866,7 +1866,7 @@
         "must_fail": true
     },
     {
-        "name": "0x46 in string",
+        "name": "Escaped 0x46 in string",
         "raw": [
             "\"\\F\""
         ],
@@ -1874,7 +1874,7 @@
         "must_fail": true
     },
     {
-        "name": "0x47 in string",
+        "name": "Escaped 0x47 in string",
         "raw": [
             "\"\\G\""
         ],
@@ -1882,7 +1882,7 @@
         "must_fail": true
     },
     {
-        "name": "0x48 in string",
+        "name": "Escaped 0x48 in string",
         "raw": [
             "\"\\H\""
         ],
@@ -1890,7 +1890,7 @@
         "must_fail": true
     },
     {
-        "name": "0x49 in string",
+        "name": "Escaped 0x49 in string",
         "raw": [
             "\"\\I\""
         ],
@@ -1898,7 +1898,7 @@
         "must_fail": true
     },
     {
-        "name": "0x4a in string",
+        "name": "Escaped 0x4a in string",
         "raw": [
             "\"\\J\""
         ],
@@ -1906,7 +1906,7 @@
         "must_fail": true
     },
     {
-        "name": "0x4b in string",
+        "name": "Escaped 0x4b in string",
         "raw": [
             "\"\\K\""
         ],
@@ -1914,7 +1914,7 @@
         "must_fail": true
     },
     {
-        "name": "0x4c in string",
+        "name": "Escaped 0x4c in string",
         "raw": [
             "\"\\L\""
         ],
@@ -1922,7 +1922,7 @@
         "must_fail": true
     },
     {
-        "name": "0x4d in string",
+        "name": "Escaped 0x4d in string",
         "raw": [
             "\"\\M\""
         ],
@@ -1930,7 +1930,7 @@
         "must_fail": true
     },
     {
-        "name": "0x4e in string",
+        "name": "Escaped 0x4e in string",
         "raw": [
             "\"\\N\""
         ],
@@ -1938,7 +1938,7 @@
         "must_fail": true
     },
     {
-        "name": "0x4f in string",
+        "name": "Escaped 0x4f in string",
         "raw": [
             "\"\\O\""
         ],
@@ -1946,7 +1946,7 @@
         "must_fail": true
     },
     {
-        "name": "0x50 in string",
+        "name": "Escaped 0x50 in string",
         "raw": [
             "\"\\P\""
         ],
@@ -1954,7 +1954,7 @@
         "must_fail": true
     },
     {
-        "name": "0x51 in string",
+        "name": "Escaped 0x51 in string",
         "raw": [
             "\"\\Q\""
         ],
@@ -1962,7 +1962,7 @@
         "must_fail": true
     },
     {
-        "name": "0x52 in string",
+        "name": "Escaped 0x52 in string",
         "raw": [
             "\"\\R\""
         ],
@@ -1970,7 +1970,7 @@
         "must_fail": true
     },
     {
-        "name": "0x53 in string",
+        "name": "Escaped 0x53 in string",
         "raw": [
             "\"\\S\""
         ],
@@ -1978,7 +1978,7 @@
         "must_fail": true
     },
     {
-        "name": "0x54 in string",
+        "name": "Escaped 0x54 in string",
         "raw": [
             "\"\\T\""
         ],
@@ -1986,7 +1986,7 @@
         "must_fail": true
     },
     {
-        "name": "0x55 in string",
+        "name": "Escaped 0x55 in string",
         "raw": [
             "\"\\U\""
         ],
@@ -1994,7 +1994,7 @@
         "must_fail": true
     },
     {
-        "name": "0x56 in string",
+        "name": "Escaped 0x56 in string",
         "raw": [
             "\"\\V\""
         ],
@@ -2002,7 +2002,7 @@
         "must_fail": true
     },
     {
-        "name": "0x57 in string",
+        "name": "Escaped 0x57 in string",
         "raw": [
             "\"\\W\""
         ],
@@ -2010,7 +2010,7 @@
         "must_fail": true
     },
     {
-        "name": "0x58 in string",
+        "name": "Escaped 0x58 in string",
         "raw": [
             "\"\\X\""
         ],
@@ -2018,7 +2018,7 @@
         "must_fail": true
     },
     {
-        "name": "0x59 in string",
+        "name": "Escaped 0x59 in string",
         "raw": [
             "\"\\Y\""
         ],
@@ -2026,7 +2026,7 @@
         "must_fail": true
     },
     {
-        "name": "0x5a in string",
+        "name": "Escaped 0x5a in string",
         "raw": [
             "\"\\Z\""
         ],
@@ -2034,7 +2034,7 @@
         "must_fail": true
     },
     {
-        "name": "0x5b in string",
+        "name": "Escaped 0x5b in string",
         "raw": [
             "\"\\[\""
         ],
@@ -2042,7 +2042,7 @@
         "must_fail": true
     },
     {
-        "name": "0x5c in string",
+        "name": "Escaped 0x5c in string",
         "raw": [
             "\"\\\\\""
         ],
@@ -2053,7 +2053,7 @@
         ]
     },
     {
-        "name": "0x5d in string",
+        "name": "Escaped 0x5d in string",
         "raw": [
             "\"\\]\""
         ],
@@ -2061,7 +2061,7 @@
         "must_fail": true
     },
     {
-        "name": "0x5e in string",
+        "name": "Escaped 0x5e in string",
         "raw": [
             "\"\\^\""
         ],
@@ -2069,7 +2069,7 @@
         "must_fail": true
     },
     {
-        "name": "0x5f in string",
+        "name": "Escaped 0x5f in string",
         "raw": [
             "\"\\_\""
         ],
@@ -2077,7 +2077,7 @@
         "must_fail": true
     },
     {
-        "name": "0x60 in string",
+        "name": "Escaped 0x60 in string",
         "raw": [
             "\"\\`\""
         ],
@@ -2085,7 +2085,7 @@
         "must_fail": true
     },
     {
-        "name": "0x61 in string",
+        "name": "Escaped 0x61 in string",
         "raw": [
             "\"\\a\""
         ],
@@ -2093,7 +2093,7 @@
         "must_fail": true
     },
     {
-        "name": "0x62 in string",
+        "name": "Escaped 0x62 in string",
         "raw": [
             "\"\\b\""
         ],
@@ -2101,7 +2101,7 @@
         "must_fail": true
     },
     {
-        "name": "0x63 in string",
+        "name": "Escaped 0x63 in string",
         "raw": [
             "\"\\c\""
         ],
@@ -2109,7 +2109,7 @@
         "must_fail": true
     },
     {
-        "name": "0x64 in string",
+        "name": "Escaped 0x64 in string",
         "raw": [
             "\"\\d\""
         ],
@@ -2117,7 +2117,7 @@
         "must_fail": true
     },
     {
-        "name": "0x65 in string",
+        "name": "Escaped 0x65 in string",
         "raw": [
             "\"\\e\""
         ],
@@ -2125,7 +2125,7 @@
         "must_fail": true
     },
     {
-        "name": "0x66 in string",
+        "name": "Escaped 0x66 in string",
         "raw": [
             "\"\\f\""
         ],
@@ -2133,7 +2133,7 @@
         "must_fail": true
     },
     {
-        "name": "0x67 in string",
+        "name": "Escaped 0x67 in string",
         "raw": [
             "\"\\g\""
         ],
@@ -2141,7 +2141,7 @@
         "must_fail": true
     },
     {
-        "name": "0x68 in string",
+        "name": "Escaped 0x68 in string",
         "raw": [
             "\"\\h\""
         ],
@@ -2149,7 +2149,7 @@
         "must_fail": true
     },
     {
-        "name": "0x69 in string",
+        "name": "Escaped 0x69 in string",
         "raw": [
             "\"\\i\""
         ],
@@ -2157,7 +2157,7 @@
         "must_fail": true
     },
     {
-        "name": "0x6a in string",
+        "name": "Escaped 0x6a in string",
         "raw": [
             "\"\\j\""
         ],
@@ -2165,7 +2165,7 @@
         "must_fail": true
     },
     {
-        "name": "0x6b in string",
+        "name": "Escaped 0x6b in string",
         "raw": [
             "\"\\k\""
         ],
@@ -2173,7 +2173,7 @@
         "must_fail": true
     },
     {
-        "name": "0x6c in string",
+        "name": "Escaped 0x6c in string",
         "raw": [
             "\"\\l\""
         ],
@@ -2181,7 +2181,7 @@
         "must_fail": true
     },
     {
-        "name": "0x6d in string",
+        "name": "Escaped 0x6d in string",
         "raw": [
             "\"\\m\""
         ],
@@ -2189,7 +2189,7 @@
         "must_fail": true
     },
     {
-        "name": "0x6e in string",
+        "name": "Escaped 0x6e in string",
         "raw": [
             "\"\\n\""
         ],
@@ -2197,7 +2197,7 @@
         "must_fail": true
     },
     {
-        "name": "0x6f in string",
+        "name": "Escaped 0x6f in string",
         "raw": [
             "\"\\o\""
         ],
@@ -2205,7 +2205,7 @@
         "must_fail": true
     },
     {
-        "name": "0x70 in string",
+        "name": "Escaped 0x70 in string",
         "raw": [
             "\"\\p\""
         ],
@@ -2213,7 +2213,7 @@
         "must_fail": true
     },
     {
-        "name": "0x71 in string",
+        "name": "Escaped 0x71 in string",
         "raw": [
             "\"\\q\""
         ],
@@ -2221,7 +2221,7 @@
         "must_fail": true
     },
     {
-        "name": "0x72 in string",
+        "name": "Escaped 0x72 in string",
         "raw": [
             "\"\\r\""
         ],
@@ -2229,7 +2229,7 @@
         "must_fail": true
     },
     {
-        "name": "0x73 in string",
+        "name": "Escaped 0x73 in string",
         "raw": [
             "\"\\s\""
         ],
@@ -2237,7 +2237,7 @@
         "must_fail": true
     },
     {
-        "name": "0x74 in string",
+        "name": "Escaped 0x74 in string",
         "raw": [
             "\"\\t\""
         ],
@@ -2245,7 +2245,7 @@
         "must_fail": true
     },
     {
-        "name": "0x75 in string",
+        "name": "Escaped 0x75 in string",
         "raw": [
             "\"\\u\""
         ],
@@ -2253,7 +2253,7 @@
         "must_fail": true
     },
     {
-        "name": "0x76 in string",
+        "name": "Escaped 0x76 in string",
         "raw": [
             "\"\\v\""
         ],
@@ -2261,7 +2261,7 @@
         "must_fail": true
     },
     {
-        "name": "0x77 in string",
+        "name": "Escaped 0x77 in string",
         "raw": [
             "\"\\w\""
         ],
@@ -2269,7 +2269,7 @@
         "must_fail": true
     },
     {
-        "name": "0x78 in string",
+        "name": "Escaped 0x78 in string",
         "raw": [
             "\"\\x\""
         ],
@@ -2277,7 +2277,7 @@
         "must_fail": true
     },
     {
-        "name": "0x79 in string",
+        "name": "Escaped 0x79 in string",
         "raw": [
             "\"\\y\""
         ],
@@ -2285,7 +2285,7 @@
         "must_fail": true
     },
     {
-        "name": "0x7a in string",
+        "name": "Escaped 0x7a in string",
         "raw": [
             "\"\\z\""
         ],
@@ -2293,7 +2293,7 @@
         "must_fail": true
     },
     {
-        "name": "0x7b in string",
+        "name": "Escaped 0x7b in string",
         "raw": [
             "\"\\{\""
         ],
@@ -2301,7 +2301,7 @@
         "must_fail": true
     },
     {
-        "name": "0x7c in string",
+        "name": "Escaped 0x7c in string",
         "raw": [
             "\"\\|\""
         ],
@@ -2309,7 +2309,7 @@
         "must_fail": true
     },
     {
-        "name": "0x7d in string",
+        "name": "Escaped 0x7d in string",
         "raw": [
             "\"\\}\""
         ],
@@ -2317,7 +2317,7 @@
         "must_fail": true
     },
     {
-        "name": "0x7e in string",
+        "name": "Escaped 0x7e in string",
         "raw": [
             "\"\\~\""
         ],
@@ -2325,7 +2325,7 @@
         "must_fail": true
     },
     {
-        "name": "0x7f in string",
+        "name": "Escaped 0x7f in string",
         "raw": [
             "\"\\\u007f\""
         ],


### PR DESCRIPTION
The allowed character and escaped character tests had the same name, so I was inadvertently overwriting test cases in my library's testsuite setup.  This change also helps distinguish the relevant test if a failure occurs.