### PR TITLE
add boolean to type mapping description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The `expected` data structure maps the types in Structured Fields to [JSON](http
    * String: JSON string; e.g., "foo"
    * Token: `token` __type Object (see below)
    * Binary Content: `binary` __type Object (see below)
+   * Boolean: JSON boolean; e.g., true
    * Date: `date` __type Object (see below)
    * Display String: `displaystring` __type Object (see below)
 * Parameters: JSON array of arrays with two element, the param name and the param value


### PR DESCRIPTION
Hello,

This PR adds a (missing) boolean entry to the type mapping description in the README.

Though it is an obvious fact that booleans are mapped to booleans,, having no missing entries in the list would be helpful to implementers.