### PR TITLE
Add must-fail tests for padding byte embedded in otherwise valid byte sequence

### DIFF
--- a/binary.json
+++ b/binary.json
@@ -16,6 +16,18 @@
             []]
     },
     {
+        "name": "padding at beginning",
+        "raw": [":=aGVsbG8=:"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
+        "name": "padding in middle",
+        "raw": [":a=GVsbG8=:"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
         "name": "bad padding",
         "raw": [":aGVsbG8:"],
         "header_type": "item",


### PR DESCRIPTION
From what I can tell, this test suite lacks coverage for a padding byte (`=`) appearing anywhere other than at the end of the encoded data.

We should have a can-fail test for this based on my reading of [RFC 9651 Section 4.2.7 Step 7](https://www.rfc-editor.org/rfc/rfc9651.html#name-parsing-a-byte-sequence) and [RFC 4648 Section 3.3](https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3), in particular the latter's:

> Furthermore, such specifications MAY ignore the pad
character, "=", treating it as non-alphabet data, if it is present
before the end of the encoded data.