### PR TITLE
Add must-fail test for use of dot as base64 padding

### DIFF
--- a/binary.json
+++ b/binary.json
@@ -26,6 +26,12 @@
         "canonical": [":aGVsbG8=:"]
     },
     {
+        "name": "bad padding dot",
+        "raw": [":aGVsbG8.:"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
         "name": "bad end delimiter",
         "raw": [":aGVsbG8="],
         "header_type": "item",


### PR DESCRIPTION
`.` is apparently used instead of `=` in some base64 variants in order to avoid having to URL-encode `=` everywhere, but per RFC 8941 and RFC 9651:

> If b64_content contains a character not included in ALPHA, DIGIT, "+", "/",
and "=", fail parsing.

As such, it is beneficial for this test suite to explicitly cover rejection of this variant.

https://httpwg.org/specs/rfc8941.html#parse-binary
https://httpwg.org/specs/rfc9651.html#parse-binary