### PR TITLE
Add must-fail test for base64 content containing only whitespace

### DIFF
--- a/binary.json
+++ b/binary.json
@@ -38,6 +38,12 @@
         "must_fail": true
     },
     {
+        "name": "all whitespace",
+        "raw": [":    :"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
         "name": "extra chars",
         "raw": [":aGVsbG!8=:"],
         "header_type": "item",


### PR DESCRIPTION
The existing "extra whitespace" test has the unfortunate coincidence of having length 4n+1, which means it can be considered invalid for other reasons. This test input has length 4n, which means that it covers precisely the rejection of whitespace, per Step 6 of https://httpwg.org/specs/rfc8941.html#rfc.section.4.2.7.