### PR TITLE
Add tests covering canonicalization of insignificant decimal digits

### DIFF
--- a/number.json
+++ b/number.json
@@ -182,5 +182,26 @@
         "raw": ["-1234567890123.0"],
         "header_type": "item",
         "must_fail": true
+    },
+    {
+        "name": "decimal with 1 significant digit and 1 insignificant digit",
+        "raw": ["1.20"],
+        "header_type": "item",
+        "expected": [1.2, []],
+        "canonical": ["1.2"]
+    },
+    {
+        "name": "decimal with 1 significant digit and 2 insignificant digits",
+        "raw": ["1.200"],
+        "header_type": "item",
+        "expected": [1.2, []],
+        "canonical": ["1.2"]
+    },
+    {
+        "name": "decimal with 2 significant digits and 1 insignificant digit",
+        "raw": ["1.230"],
+        "header_type": "item",
+        "expected": [1.23, []],
+        "canonical": ["1.23"]
     }
 ]


### PR DESCRIPTION
Per Step 9 of https://httpwg.org/specs/rfc9651.html#ser-decimal only the significant digits of the decimal's fractional component should be included in the serialized form.

From what I can tell, there is no coverage of this today.

Fixes #99.