### PR TITLE
Add test for display string containing unescaped non-ASCII characters

### DIFF
--- a/display-string.json
+++ b/display-string.json
@@ -25,6 +25,12 @@
         "expected": [{"__type": "displaystring", "value": "füü"}, []]
     },
     {
+        "name": "non-ascii display string (unescaped)",
+        "raw": ["%\"füü\""],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
         "name": "tab in display string",
         "raw": ["%\"\t\""],
         "header_type": "item",


### PR DESCRIPTION
The existing tests only cover the presence of non-visible ASCII characters in display strings from Step 4.2 of https://httpwg.org/specs/rfc9651.html#parse-display.