### PR TITLE
Add can-fail tests for string and display string split over two lines

### DIFF
--- a/display-string.json
+++ b/display-string.json
@@ -113,5 +113,12 @@
         "raw": ["%\"BOM: %ef%bb%bf\""],
         "header_type": "item",
         "expected": [{"__type": "displaystring", "value": "BOM: \uFEFF"}, []]
+    },
+    {
+        "name": "two lines display string",
+        "raw": ["%\"foo", "bar\""],
+        "header_type": "item",
+        "can_fail": "true",
+        "expected": [{"__type": "displaystring", "value": "foo, bar"}, []]
     }
 ]

--- a/string.json
+++ b/string.json
@@ -76,5 +76,12 @@
         "raw": ["\"foo \\"],
         "header_type": "item",
         "must_fail": true
+    },
+    {
+        "name": "two lines string",
+        "raw": ["\"foo", "bar\""],
+        "header_type": "item",
+        "can_fail": "true",
+        "expected": ["foo, bar", []]
     }
 ]


### PR DESCRIPTION
Per https://httpwg.org/specs/rfc9651.html#text-parse:

> Parsers MAY fail when processing a field value spread across multiple field
lines, when one of those lines does not parse as that field.