### PR TITLE
fix: can_fail is supposed to be a boolean

### DIFF
--- a/display-string.json
+++ b/display-string.json
@@ -118,7 +118,7 @@
         "name": "two lines display string",
         "raw": ["%\"foo", "bar\""],
         "header_type": "item",
-        "can_fail": "true",
+        "can_fail": true,
         "expected": [{"__type": "displaystring", "value": "foo, bar"}, []]
     }
 ]

--- a/string.json
+++ b/string.json
@@ -81,7 +81,7 @@
         "name": "two lines string",
         "raw": ["\"foo", "bar\""],
         "header_type": "item",
-        "can_fail": "true",
+        "can_fail": true,
         "expected": ["foo, bar", []]
     }
 ]


### PR DESCRIPTION
The README describes the `can_fail` field to be a boolean.
A strict parser may fail to load these two test cases