### PR TITLE
Validate test files using JSON schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Validation Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 'schema'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm install
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ or non-canonical value.  The `expected` structure (as defined above) should seri
 `canonical` form, unless `must_fail` is `true` -- in which case the value cannot be serialised.
 These cases do not have a `raw` element.
 
+[JSON Schemas](https://json-schema.org/) for these formats are provided in the `schemas` directory.
+
 ### __type Objects
 
 Because JSON doesn't natively accommodate some data types that Structured Fields does, the `expected` member uses an object with a `__type` member and a `value` member to represent these values.

--- a/display-string.json
+++ b/display-string.json
@@ -14,7 +14,6 @@
     {
         "name": "non-ascii display string (uppercase escaping)",
         "raw": ["%\"f%C3%BC%C3%BC\""],
-        "canonical": ["%\"f%c3%bc%c3%bc\""],
         "header_type": "item",
         "must_fail": true
     },

--- a/schema/.gitignore
+++ b/schema/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,8 @@
+This directory contains schemas for validating the test files in `..`
+and `../serialisation-tests`.
+
+Validate them with:
+
+```sh
+npm test
+```

--- a/schema/expected.schema.json
+++ b/schema/expected.schema.json
@@ -1,0 +1,109 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/httpwg/structured-field-tests/schema/expected.schema.json",
+    "type": "object",
+    "required": ["header_type", "expected"],
+    "oneOf": [
+        {
+            "properties": {
+                "header_type": { "const": "item" },
+                "expected": { "$ref": "#/$defs/item" }
+            }
+        },
+        {
+            "properties": {
+                "header_type": { "const": "list" },
+                "expected": { "$ref": "#/$defs/list" }
+            }
+        },
+        {
+            "properties": {
+                "header_type": { "const": "dictionary" },
+                "expected": { "$ref": "#/$defs/dictionary" }
+            }
+        }
+    ],
+    "$defs": {
+        "bare_item": {
+            "oneOf": [
+                { "type": "boolean" },
+                { "type": "number" },
+                { "type": "string" },
+                {
+                    "type": "object",
+                    "required": ["__type", "value"],
+                    "unevaluatedProperties": false,
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "__type": { "enum": ["binary", "displaystring", "token"] },
+                                "value": { "type": "string" }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "__type": { "const": "date" },
+                                "value": { "type": "number" }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "parameters": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "prefixItems": [
+                    { "type": "string" },
+                    { "$ref": "#/$defs/bare_item" }
+                ]
+            }
+        },
+        "item": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "prefixItems": [
+                { "$ref": "#/$defs/bare_item" },
+                { "$ref": "#/$defs/parameters" }
+            ]
+        },
+        "inner_list": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "prefixItems": [
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/item" }
+                },
+                { "$ref": "#/$defs/parameters" }
+            ]
+        },
+        "member": {
+            "oneOf": [
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/inner_list" }
+            ]
+        },
+        "list": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/member" }
+        },
+        "dictionary": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "prefixItems": [
+                    { "type": "string" },
+                    { "$ref": "#/$defs/member" }
+                ]
+            }
+        }
+    }
+}

--- a/schema/package.json
+++ b/schema/package.json
@@ -1,0 +1,14 @@
+{
+    "private": true,
+    "config": {
+        "ajv_args": "--strict -r expected.schema.json"
+    },
+    "scripts": {
+        "test": "npm run validate-parse && npm run validate-serialize",
+        "validate-parse": "ajv validate $npm_package_config_ajv_args -s parse.schema.json ../*.json",
+        "validate-serialize": "ajv validate $npm_package_config_ajv_args -s serialize.schema.json ../serialisation-tests/*.json"
+    },
+    "dependencies": {
+        "@jirutka/ajv-cli": "^6.0.0"
+    }
+}

--- a/schema/parse.schema.json
+++ b/schema/parse.schema.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/httpwg/structured-field-tests/schema/parse.schema.json",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "raw": { "$ref": "#/$defs/string_array" },
+            "must_fail": { "type": "boolean" },
+            "can_fail": { "type": "boolean" }
+        },
+        "required": ["name", "raw"],
+        "unevaluatedProperties": false,
+        "if": {
+            "properties": {
+                "must_fail": { "const": true }
+            },
+            "required": ["must_fail"]
+        },
+        "then": {
+            "properties": {
+                "can_fail": { "const": true },
+                "header_type": { "enum": ["item", "list", "dictionary"] }
+            },
+            "required": ["header_type"]
+        },
+        "else": {
+            "$ref": "https://github.com/httpwg/structured-field-tests/schema/expected.schema.json",
+            "properties": {
+                "canonical": { "$ref": "#/$defs/string_array" }
+            }
+        }
+    },
+    "$defs": {
+        "string_array": {
+            "type": "array",
+            "items": { "type": "string" }
+        }
+    }
+}

--- a/schema/serialize.schema.json
+++ b/schema/serialize.schema.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/httpwg/structured-field-tests/schema/serialize.schema.json",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "$ref": "https://github.com/httpwg/structured-field-tests/schema/expected.schema.json",
+        "properties": {
+            "name": { "type": "string" },
+            "must_fail": { "type": "boolean" }
+        },
+        "required": ["name"],
+        "unevaluatedProperties": false,
+        "if": {
+            "properties": {
+                "must_fail": { "const": false }
+            }
+        },
+        "then": {
+            "properties": {
+                "canonical": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                }
+            },
+            "required": ["canonical"]
+        }
+    }
+}


### PR DESCRIPTION
And fix a `must_fail` test that had an erroneous `canonical` field.

Fixes #107